### PR TITLE
metadata: update location

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -4,7 +4,7 @@
 title: 'Top-Level Await'
 status: proposal
 stage: 2
-location: https://mylesborins.github.io/proposal-top-level-await/
+location: https://tc39.github.io/proposal-top-level-await/
 copyright: false
 contributors: Myles Borins
 </pre>


### PR DESCRIPTION
The repo was moved from [mylesborins/proposal-top-level-await](https://github.com/mylesborins/proposal-top-level-await) to [tc39/proposal-top-level-await](https://github.com/tc39/proposal-top-level-await), the old GitHub Pages link no longer works.