### PR TITLE
Variant B promise refactoring

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -80,6 +80,27 @@ contributors: Myles Borins
   </emu-alg>
 </emu-clause>
 
+<emu-clause id="sec-awaitall" aoid="AwaitAll">
+    <h1><ins>AwaitAll( _promises_ )</ins></h1>
+    <emu-alg>
+      1. Let _resolveCapability_ be ! NewPromiseCapability(%Promise%).
+      1. Let _index_ be 0.
+      1. Let _fullfilledCount_ be 0.
+      1. Let _total_ be the length of the list _promises_.
+      1. For each Promise _promises_ in _promises_, do
+        1. Let _stepsFulfilled_ be the following steps with argument _arg_
+          1. Set _fulfilledCount_ to _fulfilledCount_ + 1.
+          1. If _fulfilledCount_ is equal to _total_, then
+            1. Perform ! Call(_resolveCapability_.[[Resolve]], *undefined*, &laquo;*undefined*&raquo;).
+        1. Let _onFulfilled_ be _CreateBuiltinFunction(_stepsFulfilled_).
+        1. Let _stepsReject_ be the following steps with argument _arg_
+          1. Perform ! Call(_resolveCapability_.[[Reject]], *undefined*, &laquo;_arg_&raquo;).
+        1. Let _onReject_ be _CreateBuiltinFunction_(_stepsReject_).
+        1. Perform ! PerformPromiseThen(_promise_, _onFulfilled_, _onRejected_).
+      1. AwaitWithReturn(_resolveCapability_.[[Promise]])).
+    </emu-alg>
+  </emu-clause>
+
 <emu-clause id="sec-performbuiltinpromisethen" aoid="PerformBuiltinPromiseThen">
   <h1><ins>PerformBuiltinPromiseThen( _builtinFunction_, _onFulfilled_, _onRejected_ )</ins></h1>
   <emu-alg>
@@ -441,8 +462,7 @@ contributors: Myles Borins
       <p>This abstract operation performs the following steps:</p>
 
       <emu-alg>
-        1. <ins>For each Promise _promise_ in _dependencyExecPromises_, do</ins>
-          1. <ins>AwaitWithReturn(_module_.[[ExecPromise]]).</ins>
+        1. <ins>Perform ? AwaitAll(_dependencyExecPromises_).</ins>
         1. Let _moduleCxt_ be a new ECMAScript code execution context.
         1. Set the Function of _moduleCxt_ to *null*.
         1. Assert: _module_.[[Realm]] is not *undefined*.

--- a/spec.html
+++ b/spec.html
@@ -66,124 +66,403 @@ contributors: Myles Borins
   </emu-alg>
 </emu-clause>
 
-<emu-clause id="sec-moduleevaluation">
-  <h1>Evaluate( ) Concrete Method</h1>
-
-  <p>The Evaluate concrete method of a Source Text Module Record implements the corresponding Module Record abstract method.</p>
-  <p><ins>By the time the promise returned by Evaluate settles, </ins>Evaluate transitions this module's [[Status]] from `"instantiated"` to `"evaluated"`.</p>
-
-  <p><del>If execution results in an exception, that exception is recorded in the [[EvaluationError]] field and rethrown by future invocations of Evaluate.</del></p>
-
-  <p><ins>If execution results in a rejected promise, the promise's rejection reason is recorded in the [[EvaluationError]] field. Future invocations of Evaluate will then return a new promise rejected with that same rejection reason.</ins></p>
-
-  <p>This abstract method performs the following steps (most of the work is done by the auxiliary function InnerModuleEvaluation):</p>
-
+<emu-clause id="sec-awaitwithreturn" aoid="AwaitWithReturn">
+  <h1><ins>AwaitWithReturn( _promise_ )</ins></h1>
   <emu-alg>
-    1. Let _module_ be this Source Text Module Record.
-    1. Assert: _module_.[[Status]] is `"instantiated"` or `"evaluated"`.
-    1. <ins>Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).</ins>
-    1. Let _stack_ be a new empty List.
-    1. Let _result_ be <ins>Await(</ins>InnerModuleEvaluation(_module_, _stack_, 0)<ins>)</ins>.
-    1. If _result_ is an abrupt completion, then
-      1. For each module _m_ in _stack_, do
-        1. Assert: _m_.[[Status]] is `"evaluating"`.
-        1. Set _m_.[[Status]] to `"evaluated"`.
-        1. Set _m_.[[EvaluationError]] to _result_.
-      1. Assert: _module_.[[Status]] is `"evaluated"` and _module_.[[EvaluationError]] is _result_.
-      1. <del>Return _result_.</del>
-      1. <ins>Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo;_result_.[[Value]]&raquo;).</ins>
-      1. <ins>Return _promiseCapability_.[[Promise]].</ins>
-    1. Assert: _module_.[[Status]] is `"evaluated"` and _module_.[[EvaluationError]] is *undefined*.
-    1. Assert: _stack_ is empty.
-    1. <del>Return *undefined*.</del>
-    1. <ins>Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo;*undefined*&raquo;).</ins>
-    1. <ins>Return _promiseCapability_.[[Promise]].</ins>
+    1. Let _resolveCapability_ be ! NewPromiseCapability(%Promise%).
+    1. Perform ! Call(_resolveCapability_.[[Resolve]], *undefined*, &laquo;_promise_&raquo;).
+    1. Let _resolvedPromise_ be _resolveCapability_.[[Promise]].
+    1. Let _stepsFulfilled_ be the following steps of the algorithm that invoked Await, with argument value.
+    1. Let _onFulfilled_ be _CreateBuiltinFunction_(_stepsFulfilled_).
+    1. Let _resultCapability_ be ! NewPromiseCapability(%Promise%).
+    1. Perform ! PerformPromiseThen(_resolvedPromise_, _onFulfilled_, *undefined*, _resultCapability_).
+    1. Return _resultCapability_.
   </emu-alg>
+</emu-clause>
 
-  <emu-clause id="sec-innermoduleevaluation" aoid="InnerModuleEvaluation">
-    <h1>InnerModuleEvaluation( _module_, _stack_, _index_ )</h1>
+<emu-clause id="sec-awaitall" aoid="AwaitAll">
+  <h1><ins>AwaitAll( _promises_ )</ins></h1>
+  <emu-alg>
+    // TODO / HELP: Spec-based Promise.all for a List of Promises
+  </emu-alg>
+</emu-clause>
 
-    <p>The InnerModuleEvaluation abstract operation is used by Evaluate to perform the actual evaluation process for the Source Text Module Record _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSIndex]] and [[DFSAncestoreIndex]] fields, are used the same way as in InnerModuleInstantiation.</p>
+<emu-clause id="sec-performbuiltinpromisethen" aoid="PerformBuiltinPromiseThen">
+  <h1><ins>PerformBuiltinPromiseThen( _builtinFunction_, _onFulfilled_, _onRejected_ )</ins></h1>
+  <emu-alg>
+    // TODO / HELP: spec-based Promise.then for a builtinFunction,
+    // returning synchronously, but adding the execution to the execution stack
+  </emu-alg>
+</emu-clause>
 
-    <p>This abstract operation performs the following steps:</p>
+<emu-clause id="sec-abstract-module-records">
+  <h1>Abstract Module Records</h1>
+  <p>A <dfn>Module Record</dfn> encapsulates structural information about the imports and exports of a single module. This information is used to link the imports and exports of sets of connected modules. A Module Record includes four fields that are only used when evaluating a module.</p>
+  <p>For specification purposes Module Record values are values of the Record specification type and can be thought of as existing in a simple object-oriented hierarchy where Module Record is an abstract class with concrete subclasses. This specification only defines a single Module Record concrete subclass named Source Text Module Record. Other specifications and implementations may define additional Module Record subclasses corresponding to alternative module definition facilities that they defined.</p>
+  <p>Module Record defines the fields listed in <emu-xref href="#table-36"></emu-xref>. All Module Definition subclasses include at least those fields. Module Record also defines the abstract method list in <emu-xref href="#table-37"></emu-xref>. All Module definition subclasses must provide concrete implementations of these abstract methods.</p>
+  <emu-table id="table-36" caption="Module Record Fields">
+    <table>
+      <thead>
+      <tr>
+        <th>
+          Field Name
+        </th>
+        <th>
+          Value Type
+        </th>
+        <th>
+          Meaning
+        </th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr>
+        <td>
+          [[Realm]]
+        </td>
+        <td>
+          Realm Record | *undefined*
+        </td>
+        <td>
+          The Realm within which this module was created. *undefined* if not yet assigned.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          [[Environment]]
+        </td>
+        <td>
+          Lexical Environment | *undefined*
+        </td>
+        <td>
+          The Lexical Environment containing the top level bindings for this module. This field is set when the module is instantiated.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          [[Namespace]]
+        </td>
+        <td>
+          Object | *undefined*
+        </td>
+        <td>
+          The Module Namespace Object (<emu-xref href="#sec-module-namespace-objects"></emu-xref>) if one has been created for this module. Otherwise *undefined*.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <ins>[[EvalPromise]]</ins>
+        </td>
+        <td>
+          <ins>Promise | *undefined*</ins>
+        </td>
+        <td>
+          <ins>The evaluation promise for this Abstract Module Record, including any dependency evaluations.</ins>
+        </td>
+      </tr>  
+      <tr>
+        <td>
+          [[HostDefined]]
+        </td>
+        <td>
+          Any, default value is *undefined*.
+        </td>
+        <td>
+          Field reserved for use by host environments that need to associate additional information with a module.
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  </emu-table>
+</emu-clause>
 
+<emu-clause id="sec-source-text-module-records">
+    <h1>Source Text Module Records</h1>
+
+    <p>A <dfn id="sourctextmodule-record">Source Text Module Record</dfn> is used to represent information about a module that was defined from ECMAScript source text (<emu-xref href="#sec-ecmascript-language-source-code"></emu-xref>) that was parsed using the goal symbol |Module|. Its fields contain digested information about the names that are imported by the module and its concrete methods use this digest to link, instantiate, and evaluate the module.</p>
+
+    <p>A Source Text Module Record can exist in a module graph with other subclasses of the abstract Module Record type. However, non-source text Module Records must not participate in dependency cycles with Source Text Module Records.</p>
+
+    <p>In addition to the fields, defined in <emu-xref href="#table-36"></emu-xref>, Source Text Module Records have the additional fields listed in <emu-xref href="#table-38"></emu-xref>. Each of these fields is initially set in ParseModule.</p>
+
+    <emu-table id="table-38" caption="Additional Fields of Source Text Module Records">
+      <table>
+        <tbody>
+        <tr>
+          <th>
+            Field Name
+          </th>
+          <th>
+            Value Type
+          </th>
+          <th>
+            Meaning
+          </th>
+        </tr>
+        <tr>
+          <td>
+            [[ECMAScriptCode]]
+          </td>
+          <td>
+            a Parse Node
+          </td>
+          <td>
+            The result of parsing the source text of this module using |Module| as the goal symbol.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            [[RequestedModules]]
+          </td>
+          <td>
+            List of String
+          </td>
+          <td>
+            A List of all the |ModuleSpecifier| strings used by the module represented by this record to request the importation of a module. The List is source code occurrence ordered.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            [[ImportEntries]]
+          </td>
+          <td>
+            List of ImportEntry Records
+          </td>
+          <td>
+            A List of ImportEntry records derived from the code of this module.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            [[LocalExportEntries]]
+          </td>
+          <td>
+            List of ExportEntry Records
+          </td>
+          <td>
+            A List of ExportEntry records derived from the code of this module that correspond to declarations that occur within the module.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            [[IndirectExportEntries]]
+          </td>
+          <td>
+            List of ExportEntry Records
+          </td>
+          <td>
+            A List of ExportEntry records derived from the code of this module that correspond to reexported imports that occur within the module.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            [[StarExportEntries]]
+          </td>
+          <td>
+            List of ExportEntry Records
+          </td>
+          <td>
+            A List of ExportEntry records derived from the code of this module that correspond to export * declarations that occur within the module.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            [[Status]]
+          </td>
+          <td>
+            String
+          </td>
+          <td>
+            Initially `"uninstantiated"`. Transitions to `"instantiating"`, `"instantiated"`, `"evaluating"`, `"evaluated"` (in that order) as the module progresses throughout its lifecycle.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <del>[[EvaluationError]]</del>
+          </td>
+          <td>
+            <del>An abrupt completion | *undefined*</del>
+          </td>
+          <td>
+            <del>A completion of type ~throw~ representing the exception that occurred during evaluation.  *undefined* if no exception occurred or if [[Status]] is not `"evaluated"`.</del>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            [[DFSIndex]]
+          </td>
+          <td>
+            Integer | *undefined*
+          </td>
+          <td>
+            Auxiliary field used during Instantiate and Evaluate only.
+            If [[Status]] is `"instantiating"` or `"evaluating"`, this non-negative number records the point at which the module was first visited during the ongoing depth-first traversal of the dependency graph.
+          </td>
+        </tr>
+        <tr>
+          <td>
+            [[DFSAncestorIndex]]
+          </td>
+          <td>
+            Integer | *undefined*
+          </td>
+          <td>
+            Auxiliary field used during Instantiate and Evaluate only. If [[Status]] is `"instantiating"` or `"evaluating"`, this is either the module's own [[DFSIndex]] or that of an "earlier" module in the same strongly connected component.
+          </td>
+        </tr>
+        </tbody>
+      </table>
+    </emu-table>
+
+  <emu-clause id="sec-parsemodule" aoid="ParseModule">
+    <h1>ParseModule ( _sourceText_, _realm_, _hostDefined_ )</h1>
+    <p>The abstract operation ParseModule with arguments _sourceText_, _realm_, and _hostDefined_ creates a Source Text Module Record based upon the result of parsing _sourceText_ as a |Module|. ParseModule performs the following steps:</p>
     <emu-alg>
-      1. <ins>Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).</ins>
-      1. If _module_ is not a Source Text Module Record, then
-        1. <del>Perform _module_.Evaluate()</del>.
-        1. <del>Return _index_.</del>
-        1. <ins>Let _evaluateResult_ be Await(! _module_.Evaluate())</ins>
-        1. <ins>If _evaluateResult_ is an abrupt completion, perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo;_evaluateResult_.[[Value]]&raquo;).</ins>
-        1. <ins>Otherwise, perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo;_index_&raquo;).</ins>
-        1. <ins>Return _promiseCapability_.[[Promise]].</ins>
-      1. If _module_.[[Status]] is `"evaluated"`, then
-        1. <del>If _module_.[[EvaluationError]] is *undefined*, return _index_.</del>
-        1. <del>Otherwise return _module_.[[EvaluationError]].</del>
-        1. <ins>If _module_.[[EvaluationError]] is an abrupt completion, perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo;_module_.[[EvaluationError]].[[Value]]&raquo;).</ins>
-        1. <ins>Otherwise, perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo;_index_&raquo;).</ins>
-        1. <ins>Return _promiseCapability_.[[Promise]]</ins>
-      1. If _module_.[[Status]] is `"evaluating"`, return _index_.
-      1. Assert: _module_.[[Status]] is `"instantiated"`.
-      1. Set _module_.[[Status]] to `"evaluating"`.
-      1. Set _module_.[[DFSIndex]] to _index_.
-      1. Set _module_.[[DFSAncestorIndex]] to _index_.
-      1. Set _index_ to _index_ + 1.
-      1. Append _module_ to _stack_.
-      1. For each String _required_ that is an element of _module_.[[RequestedModules]], do
-        1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
-        1. NOTE: Instantiate must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
-        1. <del>Set _index_ to ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_).</del>
-        1. <ins>Let _childResult_ be Await(! InnerModuleEvaluation(_requiredModule_, _stack_, _index_).</ins>
-        1. <ins>IfAbruptRejectPromise(_childResult_, _promiseCapability_).
-        1. Assert: _requiredModule_.[[Status]] is either `"evaluating"` or `"evaluated"`.
-        1. Assert: _requiredModule_.[[Status]] is `"evaluating"` if and only if _requiredModule_ is in _stack_.
-        1. If _requiredModule_.[[Status]] is `"evaluating"`, then
-          1. Assert: _requiredModule_ is a Source Text Module Record.
-          1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
-      1. <del>Perform ? ModuleExecution(_module_).</del>
-      1. <ins>Let _executionResult_ be Await(! ModuleExecution(_module_)).</ins>
-      1. <ins>IfAbruptRejectPromise(_executionResult_, _promiseCapability_).
-      1. Assert: _module_ occurs exactly once in _stack_.
-      1. Assert: _module_.[[DFSAncestorIndex]] is less than or equal to _module_.[[DFSIndex]].
-      1. If _module_.[[DFSAncestorIndex]] equals _module_.[[DFSIndex]], then
-        1. Let _done_ be *false*.
-        1. Repeat, while _done_ is *false*,
-          1. Let _requiredModule_ be the last element in _stack_.
-          1. Remove the last element of _stack_.
-          1. Set _requiredModule_.[[Status]] to `"evaluated"`.
-          1. If _requiredModule_ and _module_ are the same Module Record, set _done_ to *true*.
-      1. <del>Return _index_.</del>
-      1. <ins>Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo;_index_&raquo;).</ins>
-      1. <ins>Return _promiseCapability_.[[Promise]]</ins>
+      1. Assert: _sourceText_ is an ECMAScript source text (see clause <emu-xref href="#sec-ecmascript-language-source-code"></emu-xref>).
+      1. Parse _sourceText_ using |Module| as the goal symbol and analyse the parse result for any Early Error conditions. If the parse was successful and no early errors were found, let _body_ be the resulting parse tree. Otherwise, let _body_ be a List of one or more *SyntaxError* or *ReferenceError* objects representing the parsing errors and/or early errors. Parsing and early error detection may be interweaved in an implementation-dependent manner. If more than one parsing error or early error is present, the number and ordering of error objects in the list is implementation-dependent, but at least one must be present.
+      1. If _body_ is a List of errors, return _body_.
+      1. Let _requestedModules_ be the ModuleRequests of _body_.
+      1. Let _importEntries_ be ImportEntries of _body_.
+      1. Let _importedBoundNames_ be ImportedLocalNames(_importEntries_).
+      1. Let _indirectExportEntries_ be a new empty List.
+      1. Let _localExportEntries_ be a new empty List.
+      1. Let _starExportEntries_ be a new empty List.
+      1. Let _exportEntries_ be ExportEntries of _body_.
+      1. For each ExportEntry Record _ee_ in _exportEntries_, do
+        1. If _ee_.[[ModuleRequest]] is *null*, then
+          1. If _ee_.[[LocalName]] is not an element of _importedBoundNames_, then
+            1. Append _ee_ to _localExportEntries_.
+          1. Else,
+            1. Let _ie_ be the element of _importEntries_ whose [[LocalName]] is the same as _ee_.[[LocalName]].
+            1. If _ie_.[[ImportName]] is `"*"`, then
+              1. Assert: This is a re-export of an imported module namespace object.
+              1. Append _ee_ to _localExportEntries_.
+            1. Else this is a re-export of a single name,
+              1. Append the ExportEntry Record { [[ModuleRequest]]: _ie_.[[ModuleRequest]], [[ImportName]]: _ie_.[[ImportName]], [[LocalName]]: *null*, [[ExportName]]: _ee_.[[ExportName]] } to _indirectExportEntries_.
+        1. Else if _ee_.[[ImportName]] is `"*"`, then
+          1. Append _ee_ to _starExportEntries_.
+        1. Else,
+          1. Append _ee_ to _indirectExportEntries_.
+      1. Return Source Text Module Record { [[Realm]]: _realm_, [[Environment]]: *undefined*, [[Namespace]]: *undefined*, <ins>[[EvalPromise]]: *undefined*, </ins>[[Status]]: `"uninstantiated"`, [[EvaluationError]]: *undefined*, [[HostDefined]]: _hostDefined_, [[ECMAScriptCode]]: _body_, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[DFSIndex]]: *undefined*, [[DFSAncestorIndex]]: *undefined* }.
     </emu-alg>
+    <emu-note>
+      <p>An implementation may parse module source text and analyse it for Early Error conditions prior to the evaluation of ParseModule for that module source text. However, the reporting of any errors must be deferred until the point where this specification actually performs ParseModule upon that source text.</p>
+    </emu-note>
   </emu-clause>
 
-  <emu-clause id="sec-moduleexecution" aoid="ModuleExecution">
-    <h1>ModuleExecution( _module_ )</h1>
+  <emu-clause id="sec-moduleevaluation">
+    <h1>Evaluate( ) Concrete Method</h1>
 
-    <p>The ModuleExecution abstract operation is used by InnerModuleEvaluation to initialize the execution context of the module and evaluate the module's code within it.</p>
+    <p>The Evaluate concrete method of a Source Text Module Record implements the corresponding Module Record abstract method.</p>
+    <p>Evaluate transitions this module's [[Status]] from `"instantiated"` to `"evaluated"`<ins>, at which point the [[EvalPromise]] Promise field is populated to a promise resolving on completion of the module execution, including its dependency executions, or the associated execution error.</ins>.</p>
 
-    <p>This abstract operation performs the following steps:</p>
+    <p>If execution results in an exception, that exception is recorded in the <del>[[EvaluationError]]</del><ins>rejection of the [[EvalPromise]]</ins> field and rethrown by future invocations of Evaluate.</del></p>
+
+    <p>This abstract method performs the following steps (most of the work is done by the auxiliary function InnerModuleEvaluation):</p>
 
     <emu-alg>
-      1. Let _moduleCxt_ be a new ECMAScript code execution context.
-      1. Set the Function of _moduleCxt_ to *null*.
-      1. Assert: _module_.[[Realm]] is not *undefined*.
-      1. Set the Realm of _moduleCxt_ to _module_.[[Realm]].
-      1. Set the ScriptOrModule of _moduleCxt_ to _module_.
-      1. Assert: _module_ has been linked and declarations in its module environment have been instantiated.
-      1. Set the VariableEnvironment of _moduleCxt_ to _module_.[[Environment]].
-      1. Set the LexicalEnvironment of _moduleCxt_ to _module_.[[Environment]].
-      1. <ins>Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).</ins>
-      1. Suspend the currently running execution context.
-      1. <ins>Perform ! AsyncBlockStart(_promiseCapability_, _module_.[[ECMAScriptCode]], _moduleCxt_).</ins>
-      1. <del>Push _moduleCxt_ on to the execution context stack; _moduleCxt_ is now the running execution context.</del>
-      1. <del>Let _result_ be the result of evaluating _module_.[[ECMAScriptCode]].</del>
-      1. <del>Suspend _moduleCxt_ and remove it from the execution context stack.</del>
-      1. Resume the context that is now on the top of the execution context stack as the running execution context.
-      1. <del>Return Completion(_result_).</del>
-      1. <ins>Return _promiseCapability_.[[Promise]].</ins>
+      1. Let _module_ be this Source Text Module Record.
+      1. Assert: _module_.[[Status]] is `"instantiated"`, `"evaluating"`<ins> or `"evaluated"`</ins>.
+      1. Let _stack_ be a new empty List.
+      1. Perform ! InnerModuleEvaluation(_module_, _stack_, 0).
+      1. <ins>Assert: _stack_ is empty.</ins>
+      1. Let _result_ be AwaitWithReturn(_module_.[[EvalPromise]]).
+      1. If _result_ is an abrupt completion, then
+        1. <del>For each module _m_ in _stack_, do</del>
+          1. <del>Assert: _m_.[[Status]] is `"evaluating"`.</del>
+          1. <del>Set _m_.[[Status]] to `"evaluated"`.</del>
+          1. <del>Set _m_.[[EvaluationError]] to _result_.</del>
+        1. <del>Assert: _module_.[[Status]] is `"evaluated"` and _module_.[[EvaluationError]] is _result_.</del>
+        1. Return _result_.
+      1. Assert: _module_.[[Status]] is `"evaluated"`<del> and _module_.[[EvaluationError]] is *undefined*</del>.
+      1. <del>Assert: _stack_ is empty.</del>
+      1. Return *undefined*.
     </emu-alg>
+
+    <emu-clause id="sec-innermoduleevaluation" aoid="InnerModuleEvaluation">
+      <h1>InnerModuleEvaluation( _module_, _stack_, _index_ )</h1>
+
+      <p>The InnerModuleEvaluation abstract operation is used by Evaluate to perform the actual evaluation process for the Source Text Module Record _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSIndex]] and [[DFSAncestoreIndex]] fields, are used the same way as in InnerModuleInstantiation.</p>
+
+      <p>This abstract operation performs the following steps:</p>
+
+      <emu-alg>
+        1. If _module_ is not a Source Text Module Record, then
+          1. <ins>Set _module_.[[EvalPromise]] to </ins>_module_.Evaluate().
+          1. Return _index_.
+        1. If _module_.[[Status]] is `"evaluated"`, then
+          1. <ins>Return _index_.</ins>
+          1. <del>If _module_.[[EvaluationError]] is *undefined*, return _index_.</del>
+          1. <del>Otherwise return _module_.[[EvaluationError]].</del>
+        1. If _module_.[[Status]] is `"evaluating"`, return _index_.
+        1. Assert: _module_.[[Status]] is `"instantiated"`.
+        1. Set _module_.[[Status]] to `"evaluating"`.
+        1. Set _module_.[[DFSIndex]] to _index_.
+        1. Set _module_.[[DFSAncestorIndex]] to _index_.
+        1. <ins>Let _evalCapability_ be ! NewPromiseCapability(%Promise%).</ins>
+        1. <ins>Set _module_.[[EvalPromise]] to _evalCapability.[[Promise]]_.
+        1. Set _index_ to _index_ + 1.
+        1. Append _module_ to _stack_.
+        1. <ins>Let _dependencyExecPromises_ be an empty List.</ins>
+        1. For each String _required_ that is an element of _module_.[[RequestedModules]], do
+          1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
+          1. NOTE: Instantiate must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
+          1. Set _index_ to ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_).
+          1. Assert: _requiredModule_.[[Status]] is either `"evaluating"` or `"evaluated"`.
+          1. Assert: _requiredModule_.[[Status]] is `"evaluating"` if and only if _requiredModule_ is in _stack_.
+          1. <ins>If _requiredModule_.[[Status]] is `"evaluated"`, then</ins>
+            1. <ins>Add _requiredModule_.[[ExecPromise]] to the list _dependencyExecPromises_.</ins>
+          1. If _requiredModule_.[[Status]] is `"evaluating"`, then
+            1. Assert: _requiredModule_ is a Source Text Module Record.
+            1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
+            1. <ins>Let _stackErrorCapability_ be ! NewPromiseCapability(%Promise%).</ins>
+            1. <ins>Perform ! PerformPromiseThen(_requiredModule_.[[ExecPromise]], *undefined*, _stackErrorCapability_.[[Reject]]).</ins>
+            1. <ins>Add _stackErrorCapability_ to the list _dependencyExecPromises_.</ins>
+        1. <del>Perform ? ModuleExecution(_module_).</del>
+        1. <ins>Let _executionSteps_ be the algorithm steps defined in ModuleExecution.</ins>
+        1. <ins>Let _execution_ be CreateBuiltinFunction(_executionSteps_, &laquo; Module, DependencyExecPromises, Resolve, Reject &raquo;).</ins>
+        1. <ins>Set _execution_.[[Module]] to _module_.</ins>
+        1. <ins>Set _execution_.[[DependencyExecPromises]] to _dependencyExecPromises_.</ins>
+        1. <ins>Perform ! PerformBuiltinPromiseThen(_execution_, _evalCapability_.[[Resolve]], _evalCapability_.[[Reject]]).</ins>
+        1. Assert: _module_ occurs exactly once in _stack_.
+        1. Assert: _module_.[[DFSAncestorIndex]] is less than or equal to _module_.[[DFSIndex]].
+        1. If _module_.[[DFSAncestorIndex]] equals _module_.[[DFSIndex]], then
+          1. Let _done_ be *false*.
+          1. Repeat, while _done_ is *false*,
+            1. Let _requiredModule_ be the last element in _stack_.
+            1. Remove the last element of _stack_.
+            1. Set _requiredModule_.[[Status]] to `"evaluated"`.
+            1. If _requiredModule_ and _module_ are the same Module Record, set _done_ to *true*.
+        1. Return _index_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-moduleexecution" aoid="ModuleExecution">
+      <h1>ModuleExecution( _module_, _dependencyExecPromises_, _resolve_, _reject_ )</h1>
+
+      <p>The ModuleExecution abstract operation is used by InnerModuleEvaluation to initialize the execution context of the module and evaluate the module's code within it.</p>
+
+      <p>This abstract operation performs the following steps:</p>
+
+      <emu-alg>
+        1. <ins>Perform ? AwaitAll(_dependencyExecPromises_).</ins>
+        1. Let _moduleCxt_ be a new ECMAScript code execution context.
+        1. Set the Function of _moduleCxt_ to *null*.
+        1. Assert: _module_.[[Realm]] is not *undefined*.
+        1. Set the Realm of _moduleCxt_ to _module_.[[Realm]].
+        1. Set the ScriptOrModule of _moduleCxt_ to _module_.
+        1. Assert: _module_ has been linked and declarations in its module environment have been instantiated.
+        1. Set the VariableEnvironment of _moduleCxt_ to _module_.[[Environment]].
+        1. Set the LexicalEnvironment of _moduleCxt_ to _module_.[[Environment]].
+        1. Suspend the currently running execution context.
+        1. <ins>Perform ! AsyncBlockStart(_promiseCapability_, _module_.[[ECMAScriptCode]], _moduleCxt_).</ins>
+        1. <del>Push _moduleCxt_ on to the execution context stack; _moduleCxt_ is now the running execution context.</del>
+        1. <del>Let _result_ be the result of evaluating _module_.[[ECMAScriptCode]].</del>
+        1. <del>Suspend _moduleCxt_ and remove it from the execution context stack.</del>
+        1. Resume the context that is now on the top of the execution context stack as the running execution context.
+        1. <ins>AwaitWithReturn(_promiseCapability_.[[Promise]])</ins>
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 </emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -151,7 +151,7 @@ contributors: Myles Borins
       </tr>
       <tr>
         <td>
-          <ins>[[EvalPromise]]</ins>
+          <ins>[[ExecPromise]]</ins>
         </td>
         <td>
           <ins>Promise | *undefined*</ins>
@@ -343,7 +343,7 @@ contributors: Myles Borins
           1. Append _ee_ to _starExportEntries_.
         1. Else,
           1. Append _ee_ to _indirectExportEntries_.
-      1. Return Source Text Module Record { [[Realm]]: _realm_, [[Environment]]: *undefined*, [[Namespace]]: *undefined*, <ins>[[EvalPromise]]: *undefined*, </ins>[[Status]]: `"uninstantiated"`, [[EvaluationError]]: *undefined*, [[HostDefined]]: _hostDefined_, [[ECMAScriptCode]]: _body_, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[DFSIndex]]: *undefined*, [[DFSAncestorIndex]]: *undefined* }.
+      1. Return Source Text Module Record { [[Realm]]: _realm_, [[Environment]]: *undefined*, [[Namespace]]: *undefined*, <ins>[[ExecPromise]]: *undefined*, </ins>[[Status]]: `"uninstantiated"`, [[EvaluationError]]: *undefined*, [[HostDefined]]: _hostDefined_, [[ECMAScriptCode]]: _body_, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[DFSIndex]]: *undefined*, [[DFSAncestorIndex]]: *undefined* }.
     </emu-alg>
     <emu-note>
       <p>An implementation may parse module source text and analyse it for Early Error conditions prior to the evaluation of ParseModule for that module source text. However, the reporting of any errors must be deferred until the point where this specification actually performs ParseModule upon that source text.</p>
@@ -354,9 +354,9 @@ contributors: Myles Borins
     <h1>Evaluate( ) Concrete Method</h1>
 
     <p>The Evaluate concrete method of a Source Text Module Record implements the corresponding Module Record abstract method.</p>
-    <p>Evaluate transitions this module's [[Status]] from `"instantiated"` to `"evaluated"`<ins>, at which point the [[EvalPromise]] Promise field is populated to a promise resolving on completion of the module execution, including its dependency executions, or the associated execution error.</ins>.</p>
+    <p>Evaluate transitions this module's [[Status]] from `"instantiated"` to `"evaluated"`<ins>, at which point the [[ExecPromise]] Promise field is populated to a promise resolving on completion of the module execution, including its dependency executions, or the associated execution error.</ins>.</p>
 
-    <p>If execution results in an exception, that exception is recorded in the <del>[[EvaluationError]]</del><ins>rejection of the [[EvalPromise]]</ins> field and rethrown by future invocations of Evaluate.</del></p>
+    <p>If execution results in an exception, that exception is recorded in the <del>[[EvaluationError]]</del><ins>rejection of the [[ExecPromise]]</ins> field and rethrown by future invocations of Evaluate.</del></p>
 
     <p>This abstract method performs the following steps (most of the work is done by the auxiliary function InnerModuleEvaluation):</p>
 
@@ -366,7 +366,7 @@ contributors: Myles Borins
       1. Let _stack_ be a new empty List.
       1. Perform ! InnerModuleEvaluation(_module_, _stack_, 0).
       1. <ins>Assert: _stack_ is empty.</ins>
-      1. Let _result_ be AwaitWithReturn(_module_.[[EvalPromise]]).
+      1. Let _result_ be AwaitWithReturn(_module_.[[ExecPromise]]).
       1. If _result_ is an abrupt completion, then
         1. <del>For each module _m_ in _stack_, do</del>
           1. <del>Assert: _m_.[[Status]] is `"evaluating"`.</del>
@@ -388,7 +388,7 @@ contributors: Myles Borins
 
       <emu-alg>
         1. If _module_ is not a Source Text Module Record, then
-          1. <ins>Set _module_.[[EvalPromise]] to </ins>_module_.Evaluate().
+          1. <ins>Set _module_.[[ExecPromise]] to </ins>_module_.Evaluate().
           1. Return _index_.
         1. If _module_.[[Status]] is `"evaluated"`, then
           1. <ins>Return _index_.</ins>
@@ -400,7 +400,7 @@ contributors: Myles Borins
         1. Set _module_.[[DFSIndex]] to _index_.
         1. Set _module_.[[DFSAncestorIndex]] to _index_.
         1. <ins>Let _evalCapability_ be ! NewPromiseCapability(%Promise%).</ins>
-        1. <ins>Set _module_.[[EvalPromise]] to _evalCapability.[[Promise]]_.
+        1. <ins>Set _module_.[[ExecPromise]] to _evalCapability.[[Promise]]_.
         1. Set _index_ to _index_ + 1.
         1. Append _module_ to _stack_.
         1. <ins>Let _dependencyExecPromises_ be an empty List.</ins>
@@ -435,6 +435,9 @@ contributors: Myles Borins
             1. If _requiredModule_ and _module_ are the same Module Record, set _done_ to *true*.
         1. Return _index_.
       </emu-alg>
+      <emu-note>
+        <p>A module is `"evaluating"` while it is being traversed by InnerModuleEvaluation. A module is `"evaluated"` when ModuleExecution has been called, even if that module execution is a promise that has not yet resolved.</p>
+      </emu-nnote>
     </emu-clause>
 
     <emu-clause id="sec-moduleexecution" aoid="ModuleExecution">

--- a/spec.html
+++ b/spec.html
@@ -80,13 +80,6 @@ contributors: Myles Borins
   </emu-alg>
 </emu-clause>
 
-<emu-clause id="sec-awaitall" aoid="AwaitAll">
-  <h1><ins>AwaitAll( _promises_ )</ins></h1>
-  <emu-alg>
-    // TODO / HELP: Spec-based Promise.all for a List of Promises
-  </emu-alg>
-</emu-clause>
-
 <emu-clause id="sec-performbuiltinpromisethen" aoid="PerformBuiltinPromiseThen">
   <h1><ins>PerformBuiltinPromiseThen( _builtinFunction_, _onFulfilled_, _onRejected_ )</ins></h1>
   <emu-alg>
@@ -448,7 +441,8 @@ contributors: Myles Borins
       <p>This abstract operation performs the following steps:</p>
 
       <emu-alg>
-        1. <ins>Perform ? AwaitAll(_dependencyExecPromises_).</ins>
+        1. <ins>For each Promise _promise_ in _dependencyExecPromises_, do</ins>
+          1. <ins>AwaitWithReturn(_module_.[[ExecPromise]]).</ins>
         1. Let _moduleCxt_ be a new ECMAScript code execution context.
         1. Set the Function of _moduleCxt_ to *null*.
         1. Assert: _module_.[[Realm]] is not *undefined*.

--- a/spec.html
+++ b/spec.html
@@ -80,27 +80,6 @@ contributors: Myles Borins
   </emu-alg>
 </emu-clause>
 
-<emu-clause id="sec-awaitall" aoid="AwaitAll">
-    <h1><ins>AwaitAll( _promises_ )</ins></h1>
-    <emu-alg>
-      1. Let _resolveCapability_ be ! NewPromiseCapability(%Promise%).
-      1. Let _index_ be 0.
-      1. Let _fullfilledCount_ be 0.
-      1. Let _total_ be the length of the list _promises_.
-      1. For each Promise _promises_ in _promises_, do
-        1. Let _stepsFulfilled_ be the following steps with argument _arg_
-          1. Set _fulfilledCount_ to _fulfilledCount_ + 1.
-          1. If _fulfilledCount_ is equal to _total_, then
-            1. Perform ! Call(_resolveCapability_.[[Resolve]], *undefined*, &laquo;*undefined*&raquo;).
-        1. Let _onFulfilled_ be _CreateBuiltinFunction(_stepsFulfilled_).
-        1. Let _stepsReject_ be the following steps with argument _arg_
-          1. Perform ! Call(_resolveCapability_.[[Reject]], *undefined*, &laquo;_arg_&raquo;).
-        1. Let _onReject_ be _CreateBuiltinFunction_(_stepsReject_).
-        1. Perform ! PerformPromiseThen(_promise_, _onFulfilled_, _onRejected_).
-      1. AwaitWithReturn(_resolveCapability_.[[Promise]])).
-    </emu-alg>
-  </emu-clause>
-
 <emu-clause id="sec-performbuiltinpromisethen" aoid="PerformBuiltinPromiseThen">
   <h1><ins>PerformBuiltinPromiseThen( _builtinFunction_, _onFulfilled_, _onRejected_ )</ins></h1>
   <emu-alg>
@@ -462,7 +441,8 @@ contributors: Myles Borins
       <p>This abstract operation performs the following steps:</p>
 
       <emu-alg>
-        1. <ins>Perform ? AwaitAll(_dependencyExecPromises_).</ins>
+        1. <ins>For each Promise _promise_ in _dependencyExecPromises_, do</ins>
+          1. <ins>AwaitWithReturn(_module_.[[ExecPromise]]).</ins>
         1. Let _moduleCxt_ be a new ECMAScript code execution context.
         1. Set the Function of _moduleCxt_ to *null*.
         1. Assert: _module_.[[Realm]] is not *undefined*.


### PR DESCRIPTION
I've made a step here towards refactoring the promise handling, based on the current suggestions of storing `[[ExecPromise]]` on the module record itself, as well as using the promises approach mentioned in https://github.com/tc39/proposal-top-level-await/issues/18#issuecomment-383719218.

My experience with the promises spec is very weak, so there are some gaps where I couldn't find appropriate spec functions for `AwaitAll` and `PerformBuiltinPromiseThen`, which I have left as to-dos. Help with this would be great, just let me know if I can explain them further at all.

Algorithmically the following approach is taken:

1. We need to ensure that the "InnerModuleEvaluation" still runs sync. That it doesn't right now is a spec bug. This is because the "evaluation" flag checks all assume we are doing a single depth-first-search algorithm, while once we introduce promises into the mix, overlapping executions can be running this algorithm resulting in invalid handling of _stack_, _status_ and _dfsIndex_.
1. To make "InnerModuleEvaluation" sync, we change the meaning of "evaluated" to mean _module.[[ExecPromise]] has been set_. The module.[[ExecPromise]] value is the promise for full evaluation of that module, including its dependencies. We then have the exec promise either resolve or reject, which is what forms the execution completion.
1. When it comes to handling the races on evaluation here, we thus effectively have the sync algorithm setting [[ExecPromise]] for all modules in the graph. If a module already has already been executed by this specific top-level run, or another, then it will have an [[ExecPromise]] already set so we can use that.
1. For error handling, we can no longer rely on the sync population of "stack" being the exact circular subgraph of execution failure in Evaluate. Instead, we simply have the rejection of [[ExecPromise]] store this for us, allowing [[EvaluationError]] to be deprecated and avoiding having to rewrite this behaviour.
1. Each parent is effectively doing Promise.all(...depModule.[[ExecPromise]]). When an already-evaluating dependency is encountered implying a cycle, we want to avoid gridlock in this case. To do this we don't resolve the parent to its [[ExecPromise]] in this case, but to ensure error handling behaviour keeps its invariant of sharing the error throughout the failed subgraph, we do propogate its rejection.
1. Once all of that is wired up by InnerModuleEvaluation, we then simply wait on the top-level module's [[ExecPromise]] to get the completion.

@domenic I would really value your feedback re how to complete the promise handling here. I will try and give it another shot again when I can, but wanted to post this early for initial feedback.