### PR TITLE
doc: s/child/parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Module a would need to finish executing before b or c could execute.
 
 ### Variant B: top-level `await` does not block sibling execution
 
-In this proposed solution a call to `top-level await` would block execution of child nodes in the graph but would allow siblings to continue to execute. 
+In this proposed solution a call to `top-level await` would block execution of parent nodes in the graph but would allow siblings to continue to execute. 
 
 In this implementation you could consider the following
 


### PR DESCRIPTION
As execution happens in post-traversal order I believe it is more accurate
to frame this a blocking of parent execution than blocking child execution.

This is the implied behavior and how it has been spec'd so far, just incorrectly
documented.