### PR TITLE
Improve the code blocks in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ import { output } from "./awaiting.mjs";
 export function outputPlusValue(value) { return output + value }
 
 console.log(outputPlusValue(100));
-setTimeout(() => console.log(outputPlusValue(100), 1000)
+setTimeout(() => console.log(outputPlusValue(100), 1000);
 ```
 
 ### Workaround: Export a Promise to represent initialization
@@ -77,7 +77,7 @@ export function outputPlusValue(value) { return output + value }
 
 promise.then(() => {
   console.log(outputPlusValue(100));
-  setTimeout(() => console.log(outputPlusValue(100), 1000)
+  setTimeout(() => console.log(outputPlusValue(100), 1000);
 });
 ```
 
@@ -107,11 +107,11 @@ export default (async () => {
 // usage.mjs
 import promise from "./awaiting.mjs";
 
-export default promise.then({output} => {
+export default promise.then(({output}) => {
   function outputPlusValue(value) { return output + value }
 
   console.log(outputPlusValue(100));
-  setTimeout(() => console.log(outputPlusValue(100), 1000)
+  setTimeout(() => console.log(outputPlusValue(100), 1000);
 
   return { outputPlusValue };
 });
@@ -139,7 +139,7 @@ import { output } from "./awaiting.mjs";
 export function outputPlusValue(value) { return output + value }
 
 console.log(outputPlusValue(100));
-setTimeout(() => console.log(outputPlusValue(100), 1000)
+setTimeout(() => console.log(outputPlusValue(100), 1000);
 ```
 
 None of the statements in `usage.mjs` will execute until the `await`s in `awaiting.mjs` have had their Promises resolve, so the race condition is avoided by design. This is an extension of how, if `awaiting.mjs` didn't use top-level `await`, none of the statements in `usage.mjs` will execute until `awaiting.mjs` is loaded and all of its statements have executed.
@@ -189,9 +189,9 @@ WebAssembly Modules are "compiled" and "instantiated" in a logically asynchronou
 Currently, a module waits for all of its dependencies to execute all of their statements before the import is considered finished, and the module's code can run. This proposal maintains this property when introducing `await`, : dependencies still execute through to the end, even if you need to wait for that execution to finish asynchronously. One way to think of this is as if each module exported a Promise, and after all the `import` statements, but before the rest of the module, the Promises are all `await`ed:
 
 ```mjs
-import { a } from './a.mjs'
-import { b } from './b.mjs'
-import { c } from './c.mjs'
+import { a } from './a.mjs';
+import { b } from './b.mjs';
+import { c } from './c.mjs';
 
 console.log(a, b, c);
 ```
@@ -199,9 +199,9 @@ console.log(a, b, c);
 would be equivalent to
 
 ```mjs
-import { promise as aPromise, a } from './a.mjs'
-import { promise as bPromise, b } from './b.mjs'
-import { promise as cPromise, c } from './c.mjs'
+import { promise as aPromise, a } from './a.mjs';
+import { promise as bPromise, b } from './b.mjs';
+import { promise as cPromise, c } from './c.mjs';
 
 export const promise = Promise.all([aPromise, bPromise, cPromise]).then(() => {
 
@@ -337,7 +337,7 @@ A potential problem space to solve for in designing top level await is to aid in
 
 The following sections about deadlock prevention will be based on this code example:
 
-```mjs
+```jsx
 // file.html
 <script type=module src="a.mjs"></script>
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This pattern is appropriate for situations where loading a module is intended to
 ```mjs
 // usage.mjs
 import { output } from "./awaiting.mjs";
-export function outputPlusValue(value) { return output + value }
+export function outputPlusValue(value) { return output + value; }
 
 console.log(outputPlusValue(100));
 setTimeout(() => console.log(outputPlusValue(100), 1000);


### PR DESCRIPTION
- Added missing semicolons
- Added missing parens in `foo({ bar } => ...)`
- Converted one codeblock to use JSX syntax highlighting to properly highlight the embedded HTML.