### PR TITLE
Update example to not block on `import`

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,9 @@ Top-level `await` lets us rely on the module system itself to handle all of thes
 ```mjs
 // awaiting.mjs
 import { process } from "./some-module.mjs";
-const dynamic = await import(computedModuleSpecifier);
-const data = await fetch(url);
-export const output = process(dynamic.default, data);
+const dynamic = import(computedModuleSpecifier);
+const data = fetch(url);
+export const output = process(await dynamic.default, await data);
 ```
 
 ```mjs


### PR DESCRIPTION
The current example falls into the anti-pattern of `await`ing too eagerly: the `fetch` cannot start until the `import` has finished, even though the `fetch` doesn’t depend on the `import` result.

Ideally, the `fetch` can kick off while the `import` is still happening; we only need to `await` when we need the data.

Feel free to take over this PR and expand this to the other examples.