### PR TITLE
Handle sync subgraph execution

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -470,75 +470,16 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. Assert: _stack_ is empty.
         1. <ins>Return _capability_.</ins>
       1. <ins>Otherwise,</ins>
-        1. <ins>Perform ! InnerModuleEvaluationAsync(_module_, _stack_, 0).</ins>
+        1. <ins>Perform ! InnerModuleEvaluation(_module_, _stack_, 0).</ins>
         1. <ins>Assert: _module_.[[Status]] is `"evaluated"`.</ins>
         1. <ins>Assert: _stack_ is empty.</ins>
         1. <ins>Return _module_.[[EvaluationPromise]].</ins>
     </emu-alg>
 
-    <emu-clause id="sec-innermoduleevaluationasync" aoid="InnerModuleEvaluationAsync">
-      <h1><ins>InnerModuleEvaluationAsync( _module_, _stack_, _index_ )</ins></h1>
-
-      <p>The InnerModuleEvaluationAsync abstract operation is used by Evaluate to perform the actual evaluation process for the asynchronous Cyclic Module Record _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSIndex]] and [[DFSAncestoreIndex]] fields, are used the same way as in InnerModuleInstantiation.</p>
-
-      <p>This abstract operation performs the following steps:</p>
-
-      <emu-alg>
-        1. If _module_ is not a Source Text Module Record, then
-          1. Perform _module_.Evaluate().
-          1. Return _index_.
-        1. Assert: _module_.[[Async]] is *true*.
-        1. If _module_.[[Status]] is `"evaluated"`, then
-          1. If _module_.[[EvaluationError]] is *undefined*, return _index_.
-          1. Otherwise return _module_.[[EvaluationError]].
-        1. If _module_.[[Status]] is `"evaluating"`, return _index_.
-        1. Assert: _module_.[[Status]] is `"instantiated"`.
-        1. Set _module_.[[Status]] to `"evaluating"`.
-        1. Set _module_.[[DFSIndex]] to _index_.
-        1. Set _module_.[[DFSAncestorIndex]] to _index_.
-        1. Set _index_ to _index_ + 1.
-        1. Append _module_ to _stack_.
-        1. Let _syncDependencies_ be an empty List.
-        1. Let _asyncDependencies_ be an empty List.
-        1. For each String _required_ that is an element of _module_.[[RequestedModules]], do
-          1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
-          1. NOTE: Instantiate must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
-          1. If _requiredModule_.[[Async]] is *true*, then
-            1. Set _index_ to ? InnerModuleEvaluationAsync(_requiredModule_, _stack_, _index_).
-          1. Assert: _requiredModule_.[[Status]] is either `"evaluating"` or `"evaluated"`.
-          1. Assert: _requiredModule_.[[Status]] is `"evaluating"` if and only if _requiredModule_ is in _stack_.
-          1. If _requiredModule_.[[Status]] is `"evaluated"`, then
-            1. If _requiredModule_.[[Async]] is *true*, then
-              1. Append _requiredModule_ to _asyncDependencies_.
-            1. Otherwise,
-              1. Append _requiredModule_ to _syncDependencies_.
-          1. If _requiredModule_.[[Status]] is `"evaluating"`, then
-            1. Assert: _requiredModule_ is a Cyclic Module Record.
-            1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
-        1. Let _completionHandlers_ be a new empty List.
-        1. Set _module_.[[AsyncExecution]] to AsyncExecution { [[Completion]]: *undefined*, [[CompletionHandlers]]: _completionHandlers_ }.
-        1. Perform ! ExecuteModuleWhenImportsReady(_module_, _asyncDependencies_, _syncDependencies_).
-        1. Assert: _module_ occurs exactly once in _stack_.
-        1. Assert: _module_.[[DFSAncestorIndex]] is less than or equal to _module_.[[DFSIndex]].
-        1. If _module_.[[DFSAncestorIndex]] equals _module_.[[DFSIndex]], then
-          1. Let _done_ be *false*.
-          1. Repeat, while _done_ is *false*,
-            1. Let _requiredModule_ be the last element in _stack_.
-            1. Remove the last element of _stack_.
-            1. Set _requiredModule_.[[Status]] to `"evaluated"`.
-            1. If _requiredModule_ and _module_ are the same Module Record, set _done_ to *true*.
-            1. Set _requiredModule_.[[AsyncExecution]] to _module_.[[AsyncExecution]].
-        1. Return _index_.
-      </emu-alg>
-      <emu-note>
-        <p>A module is `"evaluating"` while it is being traversed by InnerModuleEvaluation. A module is `"evaluated"` when ModuleExecution has been called, even if that module execution is a promise that has not yet resolved.</p>
-      </emu-note>
-    </emu-clause>
-
     <emu-clause id="sec-innermoduleevaluation" aoid="InnerModuleEvaluation">
       <h1>InnerModuleEvaluation( _module_, _stack_, _index_ )</h1>
 
-      <p>The InnerModuleEvaluation abstract operation is used by Evaluate to perform the actual evaluation process for the <ins>synchronous</ins> Cyclic Module Record _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSIndex]] and [[DFSAncestoreIndex]] fields, are used the same way as in InnerModuleInstantiation.</p>
+      <p>The InnerModuleEvaluation abstract operation is used by Evaluate to perform the actual evaluation process for the Cyclic Module Record _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSIndex]] and [[DFSAncestoreIndex]] fields, are used the same way as in InnerModuleInstantiation.</p>
 
       <p>This abstract operation performs the following steps:</p>
 
@@ -546,7 +487,6 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. If _module_ is not a Source Text Module Record, then
           1. Perform _module_.Evaluate().
           1. Return _index_.
-        1. <ins>Assert: _module_.[[Async]] is *false*.</ins>
         1. If _module_.[[Status]] is `"evaluated"`, then
           1. If _module_.[[EvaluationError]] is *undefined*, return _index_.
           1. Otherwise return _module_.[[EvaluationError]].
@@ -557,16 +497,30 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. Set _module_.[[DFSAncestorIndex]] to _index_.
         1. Set _index_ to _index_ + 1.
         1. Append _module_ to _stack_.
+        1. <ins>Let _syncDependencies_ be an empty List.</ins>
+        1. <ins>Let _asyncDependencies_ be an empty List.</ins>
         1. For each String _required_ that is an element of _module_.[[RequestedModules]], do
           1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
           1. NOTE: Instantiate must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
-          1. Set _index_ to ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_).
+          1. <ins>If _module_.[[Async]] is *false* or _requiredModule_.[[Async]] is *true*, then</ins>
+            1. <ins>Note: Synchronous dependencies of async modules have their execution deferred.</ins>
+            1. Set _index_ to ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_).
           1. Assert: _requiredModule_.[[Status]] is either `"evaluating"` or `"evaluated"`.
           1. Assert: _requiredModule_.[[Status]] is `"evaluating"` if and only if _requiredModule_ is in _stack_.
           1. If _requiredModule_.[[Status]] is `"evaluating"`, then
             1. Assert: _requiredModule_ is a Cyclic Module Record.
             1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
-          1. Perform ? _module_.ExecuteModule().
+          1. <ins>If _module_.[[Async]] is *true*, then</ins>
+            1. <ins>If _requiredModule_.[[Async]] is *true*, then</ins>
+              1. <ins>Append _requiredModule_ to _asyncDependencies_.</ins>
+            1. <ins>Otherwise,</ins>
+              1. <ins>Append _requiredModule_ to _syncDependencies_.</ins>
+          1. <ins>Otherwise,</ins>
+            1. Perform ? _module_.ExecuteModule().
+        1. <ins>If _module_.[[Async]] is *true*, then</ins>
+          1. <ins>Let _completionHandlers_ be a new empty List.</ins>
+          1. <ins>Set _module_.[[AsyncExecution]] to AsyncExecution { [[Completion]]: *undefined*, [[CompletionHandlers]]: _completionHandlers_ }.</ins>
+          1. <ins>Perform ! ExecuteModuleWhenImportsReady(_module_, _asyncDependencies_, _syncDependencies_).</ins>
         1. Assert: _module_ occurs exactly once in _stack_.
         1. Assert: _module_.[[DFSAncestorIndex]] is less than or equal to _module_.[[DFSIndex]].
         1. If _module_.[[DFSAncestorIndex]] equals _module_.[[DFSIndex]], then
@@ -576,6 +530,8 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
             1. Remove the last element of _stack_.
             1. Set _requiredModule_.[[Status]] to `"evaluated"`.
             1. If _requiredModule_ and _module_ are the same Module Record, set _done_ to *true*.
+            1. <ins>Otherwise, if _module_.[[Async]] is *true*, then</ins>
+              1. <ins>Set _requiredModule_.[[AsyncExecution]] to _module_.[[AsyncExecution]].</ins>
         1. Return _index_.
       </emu-alg>
       <emu-note>

--- a/spec.html
+++ b/spec.html
@@ -119,17 +119,6 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
       </tr>
       <tr>
         <td>
-          [[HostDefined]]
-        </td>
-        <td>
-          Any, default value is *undefined*.
-        </td>
-        <td>
-          Field reserved for use by host environments that need to associate additional information with a module.
-        </td>
-      </tr>
-      <tr>
-        <td>
           <ins>[[Async]]</ins>
         </td>
         <td>
@@ -141,13 +130,66 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
       </tr>
       <tr>
         <td>
-          <ins>[[EvaluationPromise]]</ins>
+          <ins>[[AsyncExecution]]</ins>
         </td>
         <td>
-          <ins>*undefined* | Promise</ins>
+          <ins>Async Execution Record | *undefined*</ins>
         </td>
         <td>
-          <ins>If [[Async]] is true, and evaluation of this module has begun, this field stores a Promise that resolves or rejects when evaluation of the module is complete.</ins>
+          <ins>If [[Async]] is true, and evaluation of this module has begun, this field stores the execution task status and handlers.</ins>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          [[HostDefined]]
+        </td>
+        <td>
+          Any, default value is *undefined*.
+        </td>
+        <td>
+          Field reserved for use by host environments that need to associate additional information with a module.
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  </emu-table>
+
+  <emu-table id="table-36a" caption="Async Execution Record Fields">
+    <table>
+      <thead>
+      <tr>
+        <th>
+          Field Name
+        </th>
+        <th>
+          Value Type
+        </th>
+        <th>
+          Meaning
+        </th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr>
+        <td>
+          [[Completion]]
+        </td>
+        <td>
+          Completion Record | *undefined*
+        </td>
+        <td>
+          The completion result for the execution, when finished, or *undefined* while execution is still in progress.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          [[CompletionHandlers]]
+        </td>
+        <td>
+          List of function objects
+        </td>
+        <td>
+          The function object listeners to call on execution completion.
         </td>
       </tr>
       </tbody>
@@ -414,7 +456,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
       1. Let _stack_ be a new empty List.
       1. <ins>If _module_.[[Async]] is *false*, then
         1. <ins>Let _capability_ be ! NewPromiseCapability(%Promise%).</ins>
-        1. Let _result_ be InnerModuleEvaluation(_module_, _stack_, 0).
+        1. Let _result_ be ? InnerModuleEvaluation(_module_, _stack_, 0).
         1. If _result_ is an abrupt completion, then
           1. For each module _m_ in _stack_, do
             1. Assert: _m_.[[Status]] is `"evaluating"`.
@@ -437,7 +479,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
     <emu-clause id="sec-innermoduleevaluationasync" aoid="InnerModuleEvaluationAsync">
       <h1><ins>InnerModuleEvaluationAsync( _module_, _stack_, _index_ )</ins></h1>
 
-      <p>The InnerModuleEvaluationASync abstract operation is used by Evaluate to perform the actual evaluation process for the asynchronous Cyclic Module Record _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSIndex]] and [[DFSAncestoreIndex]] fields, are used the same way as in InnerModuleInstantiation.</p>
+      <p>The InnerModuleEvaluationAsync abstract operation is used by Evaluate to perform the actual evaluation process for the asynchronous Cyclic Module Record _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSIndex]] and [[DFSAncestoreIndex]] fields, are used the same way as in InnerModuleInstantiation.</p>
 
       <p>This abstract operation performs the following steps:</p>
 
@@ -473,9 +515,9 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
           1. If _requiredModule_.[[Status]] is `"evaluating"`, then
             1. Assert: _requiredModule_ is a Cyclic Module Record.
             1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
-        1. Let _capability_ be ! NewPromiseCapability(%Promise%).
-        1. Set _module_.[[EvaluationPromise]] to _capability_.[[Promise]].
-        1. Perform ! ExecuteModuleWhenAsyncImportsReady(_module_, _asyncDependencies_, _syncDependencies_, _capability_).
+        1. Let _completionHandlers_ be a new empty List.
+        1. Set _module_.[[AsyncExecution]] to AsyncExecution { [[Completion]]: *undefined*, [[CompletionHandlers]]: _completionHandlers_ }.
+        1. Perform ! ExecuteModuleWhenImportsReady(_module_, _asyncDependencies_, _syncDependencies_).
         1. Assert: _module_ occurs exactly once in _stack_.
         1. Assert: _module_.[[DFSAncestorIndex]] is less than or equal to _module_.[[DFSIndex]].
         1. If _module_.[[DFSAncestorIndex]] equals _module_.[[DFSIndex]], then
@@ -485,8 +527,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
             1. Remove the last element of _stack_.
             1. Set _requiredModule_.[[Status]] to `"evaluated"`.
             1. If _requiredModule_ and _module_ are the same Module Record, set _done_ to *true*.
-            1. Otherwise, if _module_.[[Async]] is *true*,
-              1. Set _requiredModule_.[[EvaluationPromise]] to _module_.[[EvaluationPromise]].
+            1. Set _requiredModule_.[[AsyncExecution]] to _module_.[[AsyncExecution]].
         1. Return _index_.
       </emu-alg>
       <emu-note>
@@ -497,7 +538,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
     <emu-clause id="sec-innermoduleevaluation" aoid="InnerModuleEvaluation">
       <h1>InnerModuleEvaluation( _module_, _stack_, _index_ )</h1>
 
-      <p>The InnerModuleEvaluationSync abstract operation is used by Evaluate to perform the actual evaluation process for the <ins>synchronous</ins> Cyclic Module Record _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSIndex]] and [[DFSAncestoreIndex]] fields, are used the same way as in InnerModuleInstantiation.</p>
+      <p>The InnerModuleEvaluation abstract operation is used by Evaluate to perform the actual evaluation process for the <ins>synchronous</ins> Cyclic Module Record _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSIndex]] and [[DFSAncestoreIndex]] fields, are used the same way as in InnerModuleInstantiation.</p>
 
       <p>This abstract operation performs the following steps:</p>
 
@@ -542,35 +583,54 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-execute-module-when-async-imports-ready" aoid="ExecuteModuleWhenAsyncImportsReady">
-      <h1><ins>ExecuteModuleWhenAsyncImportsReady( _module_, _asyncDependencies_, _syncDependencies_, _capability_ )</ins></h1>
+    <emu-clause id="sec-module-completion" aoid="ModuleCompletion">
+      <h1><ins>AsyncModuleCompletion( _module_, _result_ )</ins></h1>
       <emu-alg>
-        1. If _asyncDependencies_ is an empty List,
-          1. Assert: _module_.[[ModuleAsync]] is *true*.
-          1. Perform ! ExecuteAsyncModule(_module, _syncDependencies_, _capability_).
-          1. Return.
-        1. Let _index_ be 0.
-        1. Let _fullfilledCount_ be 0.
-        1. Let _total_ be the length of the List _promises_.
-        1. For each Module _module_ in _asyncDependencies_, do
-          1. Assert: _module_.[[EvaluationPromise]] is a Promise.
-          1. Let _promise_ be _module_.[[EvaluationPromise]].
-          1. Let _stepsFulfilled_ be the following steps with argument _arg_
-            1. Assert: _arg_ is *undefined*.
-            1. Set _fulfilledCount_ to _fulfilledCount_ + 1.
-            1. If _fulfilledCount_ is equal to _total_, then
-              1. Perform ! ExecuteAsyncModule(_module_, _syncDependencies_, _capability_).
-          1. Let _onFulfilled_ be CreateBuiltinFunction(_stepsFulfilled_).
-          1. Let _stepsReject_ be the following steps with argument _arg_
-            1. Perform ! Call(_capability_.[[Reject]], *undefined*, &laquo;_arg_&raquo;).
-          1. Let _onReject_ be CreateBuiltinFunction(_stepsReject_).
-          1. Perform ! PerformPromiseThen(_promise_, _onFulfilled_, _onRejected_).
+        1. Assert: _module_.[[Async]] is *true*.
+        1. Assert: _module_.[[AsyncExecution]] is an Async Execution Record.
+        1. Assert: _result_ is a Completion Record.
+        1. Let _execution_ be _module_.[[AsyncExecution]].
+        1. If _execution_.[[Completion]] is *undefined*, then
+          1. Set _execution_.[[Completion]] to _result_.
+          1. For each function object _handler_ in _execution_.[[CompletionHandlers]], do
+            1. Perform ! Call(_handler_, *undefined*, &laquo;_result_&raquo;).
+        1. Assert: _module_.[[Completion]] is Completion Record.
         1. Return.
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-execute-async-module" aoid="ExecuteAsyncModule">
-      <h1><ins>ExecuteAsyncModule( _module_, _syncDependencies_, _capability_ )</ins></h1>
+    <emu-clause id="sec-execute-module-when-imports-ready" aoid="ExecuteModuleWhenImportsReady">
+      <h1><ins>ExecuteModuleWhenImportsReady( _module_, _asyncDependencies_, _syncDependencies_ )</ins></h1>
+      <emu-alg>
+        1. If _asyncDependencies_ is an empty List,
+          1. Assert: _module_.[[ModuleAsync]] is *true*.
+          1. Perform ! ExecuteModuleWhenSyncImportsReady(_module, _syncDependencies_).
+          1. Return.
+        1. Let _index_ be 0.
+        1. Let _fullfilledCount_ be 0.
+        1. Let _total_ be the length of the List _asyncDependencies_.
+        1. For each Module _module_ in _asyncDependencies_, do
+          1. Assert: _module_.[[AsyncExecution]] is an Async Execution Record.
+          1. Let _asyncExecution_ be _module_.[[AsyncExecution]].
+          1. Let _stepsHandler_ be the following steps with argument _result_
+            1. Assert: _result_ is a Completion Record.
+            1. If _result_ is an abrupt completion, then
+              1. Perform ! AsyncModuleCompletion(_module_, _result_).
+            1. Otherwise,
+              1. Set _fulfilledCount_ to _fulfilledCount_ + 1.
+              1. If _fulfilledCount_ is equal to _total_, then
+                1. Perform ! ExecuteModuleWhenSyncImportsReady(_module_, _syncDependencies_).
+          1. Let _handler_ be CreateBuiltinFunction(_stepsHandler_).
+          1. If _asyncExecution_.[[Completion]] is not *undefined*, then
+            1. Perform ! Call(_handler_, *undefined*, &laquo;_asyncExecution_.[[Completion]]_&raquo;).
+          1. Otherwise,
+            1. Append _handler_ to _asyncExecution_.[[CompletionHandlers]].
+        1. Return.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-execute-module-when-sync-imports-ready" aoid="ExecuteModuleWhenSyncImportsReady">
+      <h1><ins>ExecuteModuleWhenSyncImportsReady( _module_, _syncDependencies_ )</ins></h1>
       <emu-alg>
         1. Assert: _module_.[[Async]] is *true*.
         1. For each Module _module_ in _syncDependencies_, do
@@ -585,29 +645,37 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
                 1. Set _m_.[[Status]] to `"evaluated"`.
                 1. Set _m_.[[EvaluationError]] to _result_.
               1. Assert: _module_.[[Status]] is `"evaluated"` and _module_.[[EvaluationError]] is _result_.
-              1. Perform ! Call(_capability_.[[Reject]], *undefined*, &laquo;_result_.[[Value]]&raquo;).
+              1. Perform ! AsyncModuleCompletion(_module_, _result_).
               1. Return.
             1. Assert _stack_ is empty.
           1. Otherwise,
             1. Assert: _module_.[[Status]] is `"evaluated"`.
             1. If _module_.[[EvaluationError]] is not *undefined*, then
-              1. Perform ! Call(_capability_.[[Reject]], *undefined*, &laquo;_result_.[[Value]]&raquo;).
+              1. Perform ! AsyncModuleCompletion(_module_, _result_).
               1. Return.
         1. If _module_.[[ModuleAsync]] is *true*, then
+          1. Let _capability_ be ! NewPromiseCapability(%Promise%).
           1. Perform ! _module_.ExecuteModule(_capability_).
+          1. Let _stepsFulfilled_ be the following steps with argument _arg_
+            1. Assert: _arg_ is *undefined*.
+            1. Let _completion_ be NormalCompletion(~empty~).
+            1. Perform ! AsyncModuleCompletion(_module_, _completion_).
+          1. Let _onFulfilled_ be CreateBuiltinFunction(_stepsFulfilled_).
+          1. Let _stepsReject_ be the following steps with argument _arg_
+            1. Let _completion_ be ThrowCompletion(_arg_).
+            1. Perform ! AsyncModuleCompletion(_module_, _completion_).
+          1. Let onRejected be CreateBuiltinFunction(stepsReject).
+          1. Perform ! PerformPromiseThen(_capability_.[[Promise]], onFulfilled, onRejected).
         1. Otherwise,
           1. Let _result_ be _module_.ExecuteModule().
-          1. If _result_ is a normal completion, then
-            1. Perform ! Call(_capability_.[[Resolve]], *undefined*, &laquo;*undefined*&raquo;).
-          1. Otherwise,
-            1. Perform ! Call(_capability_.[[Reject]], *undefined*, &laquo;_result_.[[Value]]&raquo;).
+          1. Perform ! AsyncModuleCompletion(_module_, _result_);
       </emu-alg>
     </emu-clause>
   </emu-clause>
 </emu-clause>
 
 <emu-clause id="sec-source-text-module-records">
-    <h1>Source Text Module Records</h1>
+  <h1>Source Text Module Records</h1>
 
   <emu-clause id="sec-parsemodule" aoid="ParseModule">
     <h1>ParseModule ( _sourceText_, _realm_, _hostDefined_ )</h1>
@@ -639,7 +707,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. Else,
           1. Append _ee_ to _indirectExportEntries_.
       1. <ins>Let _async_ be _body_ Contains |AwaitExpression|.</ins>
-      1. Return Source Text Module Record { [[Realm]]: _realm_, [[Environment]]: *undefined*, [[Namespace]]: *undefined*, <ins>[[EvaluationPromise]]: *undefined*, </ins>[[Status]]: `"uninstantiated"`, [[EvaluationError]]: *undefined*, [[HostDefined]]: _hostDefined_, [[ECMAScriptCode]]: _body_, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[DFSIndex]]: *undefined*, [[DFSAncestorIndex]]: *undefined*, <ins>[[Async]]: _async_, [[ModuleAsync]]: _async_</ins> }.
+      1. Return Source Text Module Record { [[Realm]]: _realm_, [[Environment]]: *undefined*, [[Namespace]]: *undefined*, <ins>[[AsyncExecution]]: *undefined*, </ins>[[Status]]: `"uninstantiated"`, [[EvaluationError]]: *undefined*, [[HostDefined]]: _hostDefined_, [[ECMAScriptCode]]: _body_, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[DFSIndex]]: *undefined*, [[DFSAncestorIndex]]: *undefined*, <ins>[[Async]]: _async_, [[ModuleAsync]]: _async_</ins> }.
     </emu-alg>
     <emu-note>
       <p>An implementation may parse module source text and analyse it for Early Error conditions prior to the evaluation of ParseModule for that module source text. However, the reporting of any errors must be deferred until the point where this specification actually performs ParseModule upon that source text.</p>

--- a/spec.html
+++ b/spec.html
@@ -454,26 +454,33 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
       1. Let _module_ be this Source Text Module Record.
       1. Assert: _module_.[[Status]] is `"instantiated"` or `"evaluated"`.
       1. Let _stack_ be a new empty List.
-      1. <ins>If _module_.[[Async]] is *false*, then
-        1. <ins>Let _capability_ be ! NewPromiseCapability(%Promise%).</ins>
-        1. Let _result_ be ? InnerModuleEvaluation(_module_, _stack_, 0).
-        1. If _result_ is an abrupt completion, then
-          1. For each module _m_ in _stack_, do
-            1. Assert: _m_.[[Status]] is `"evaluating"`.
-            1. Set _m_.[[Status]] to `"evaluated"`.
-            1. Set _m_.[[EvaluationError]] to _result_.
-          1. Assert: _module_.[[Status]] is `"evaluated"` and _module_.[[EvaluationError]] is _result_.
+      1. <ins>Let _capability_ be ! NewPromiseCapability(%Promise%).</ins>
+      1. Let _result_ be ? InnerModuleEvaluation(_module_, _stack_, 0).
+      1. If _result_ is an abrupt completion, then
+        1. <ins>Assert: _module_.[[Async]] is *false*</ins>.
+        1. For each module _m_ in _stack_, do
+          1. Assert: _m_.[[Status]] is `"evaluating"`.
+          1. Set _m_.[[Status]] to `"evaluated"`.
+          1. Set _m_.[[EvaluationError]] to _result_.
+        1. Assert: _module_.[[Status]] is `"evaluated"` and _module_.[[EvaluationError]] is _result_.
+        1. <ins>Perform ! Call(_capability_.[[Reject]], *undefined*, &laquo;_result_.[[Value]]&raquo;).</ins>
+        1. Return <del>_result_</del><ins>_capability_</ins>.
+      1. <del>Assert: _module_.[[Status]] is `"evaluated"` and _module_.[[EvaluationError]] is *undefined*.</del>
+      1. Assert: _stack_ is empty.
+      1. <ins>If _module_.[[Async]] is *false*, then</ins>
+        1. <ins>Assert: _module_.[[Status]] is `"evaluated"` and _module_.[[EvaluationError]] is *undefined*.</ins>
+        1. <ins>Perform ! Call(_capability_.[[Resolve]], *undefined*, &laquo;*undefined*&raquo;).</ins>
+        1. <ins>Return _capability_.</ins>
+      1. <ins>Assert: _module_.[[AsyncExecution]] is an Async Execution Record.</ins>
+      1. <ins>Let _stepsHandler_ be the following steps with argument _result_</ins>
+        1. <ins>Assert: _result_ is a Completion Record.</ins>
+        1. <ins>If _result_ is an abrupt completion, then</ins>
           1. <ins>Perform ! Call(_capability_.[[Reject]], *undefined*, &laquo;_result_.[[Value]]&raquo;).</ins>
         1. <ins>Otherwise,</ins>
           1. <ins>Perform ! Call(_capability_.[[Resolve]], *undefined*, &laquo;*undefined*&raquo;).</ins>
-        1. Assert: _module_.[[Status]] is `"evaluated"` and _module_.[[EvaluationError]] is *undefined*.
-        1. Assert: _stack_ is empty.
-        1. <ins>Return _capability_.</ins>
-      1. <ins>Otherwise,</ins>
-        1. <ins>Perform ! InnerModuleEvaluation(_module_, _stack_, 0).</ins>
-        1. <ins>Assert: _module_.[[Status]] is `"evaluated"`.</ins>
-        1. <ins>Assert: _stack_ is empty.</ins>
-        1. <ins>Return _module_.[[EvaluationPromise]].</ins>
+      1. <ins>Let _handler_ be CreateBuiltinFunction(_stepsHandler_).</ins>
+      1. <ins>Append _handler_ to _module_.[[AsyncExecution]].[[CompletionHandlers]].</ins>
+      1. Return <del>*undefined*</del><ins>_capability_</ins>.
     </emu-alg>
 
     <emu-clause id="sec-innermoduleevaluation" aoid="InnerModuleEvaluation">

--- a/spec.html
+++ b/spec.html
@@ -412,25 +412,32 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
       1. Let _module_ be this Source Text Module Record.
       1. Assert: _module_.[[Status]] is `"instantiated"` or `"evaluated"`.
       1. Let _stack_ be a new empty List.
-      1. Let _result_ be InnerModuleEvaluation(_module_, _stack_, 0).
-      1. If _result_ is an abrupt completion, then
-        1. For each module _m_ in _stack_, do
-          1. Assert: _m_.[[Status]] is `"evaluating"`.
-          1. <ins>If _m_.[[Async]] is *true*, return _result_.</ins>
-          1. Set _m_.[[Status]] to `"evaluated"`.
-          1. Set _m_.[[EvaluationError]] to _result_.
-        1. Assert: _module_.[[Status]] is `"evaluated"` and _module_.[[EvaluationError]] is _result_.
-        1. Return _result_.
-      1. Assert: _module_.[[Status]] is `"evaluated"` and _module_.[[EvaluationError]] is *undefined*.
-      1. Assert: _stack_ is empty.
-      1. <ins>If _module_.[[Async]] is *true*, return _module_.[[EvaluationPromise]].</ins>
-      1. <ins>Otherwise</ins>, return *undefined*.
+      1. <ins>If _module_.[[Async]] is *false*, then
+        1. <ins>Let _capability_ be ! NewPromiseCapability(%Promise%).</ins>
+        1. Let _result_ be InnerModuleEvaluation(_module_, _stack_, 0).
+        1. If _result_ is an abrupt completion, then
+          1. For each module _m_ in _stack_, do
+            1. Assert: _m_.[[Status]] is `"evaluating"`.
+            1. Set _m_.[[Status]] to `"evaluated"`.
+            1. Set _m_.[[EvaluationError]] to _result_.
+          1. Assert: _module_.[[Status]] is `"evaluated"` and _module_.[[EvaluationError]] is _result_.
+          1. <ins>Perform ! Call(_capability_.[[Reject]], *undefined*, &laquo;_result_.[[Value]]&raquo;).</ins>
+        1. <ins>Otherwise,</ins>
+          1. <ins>Perform ! Call(_capability_.[[Resolve]], *undefined*, &laquo;*undefined*&raquo;).</ins>
+        1. Assert: _module_.[[Status]] is `"evaluated"` and _module_.[[EvaluationError]] is *undefined*.
+        1. Assert: _stack_ is empty.
+        1. <ins>Return _capability_.</ins>
+      1. <ins>Otherwise,</ins>
+        1. <ins>Perform ! InnerModuleEvaluationAsync(_module_, _stack_, 0).</ins>
+        1. <ins>Assert: _module_.[[Status]] is `"evaluated"`.</ins>
+        1. <ins>Assert: _stack_ is empty.</ins>
+        1. <ins>Return _module_.[[EvaluationPromise]].</ins>
     </emu-alg>
 
-    <emu-clause id="sec-innermoduleevaluation" aoid="InnerModuleEvaluation">
-      <h1>InnerModuleEvaluation( _module_, _stack_, _index_ )</h1>
+    <emu-clause id="sec-innermoduleevaluationasync" aoid="InnerModuleEvaluationAsync">
+      <h1><ins>InnerModuleEvaluationAsync( _module_, _stack_, _index_ )</ins></h1>
 
-      <p>The InnerModuleEvaluation abstract operation is used by Evaluate to perform the actual evaluation process for the Cyclic Module Record _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSIndex]] and [[DFSAncestoreIndex]] fields, are used the same way as in InnerModuleInstantiation.</p>
+      <p>The InnerModuleEvaluationASync abstract operation is used by Evaluate to perform the actual evaluation process for the asynchronous Cyclic Module Record _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSIndex]] and [[DFSAncestoreIndex]] fields, are used the same way as in InnerModuleInstantiation.</p>
 
       <p>This abstract operation performs the following steps:</p>
 
@@ -438,6 +445,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. If _module_ is not a Source Text Module Record, then
           1. Perform _module_.Evaluate().
           1. Return _index_.
+        1. Assert: _module_.[[Async]] is *true*.
         1. If _module_.[[Status]] is `"evaluated"`, then
           1. If _module_.[[EvaluationError]] is *undefined*, return _index_.
           1. Otherwise return _module_.[[EvaluationError]].
@@ -448,25 +456,26 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. Set _module_.[[DFSAncestorIndex]] to _index_.
         1. Set _index_ to _index_ + 1.
         1. Append _module_ to _stack_.
-        1. <ins>Let _asyncDependencies_ be an empty List.</ins>
+        1. Let _syncDependencies_ be an empty List.
+        1. Let _asyncDependencies_ be an empty List.
         1. For each String _required_ that is an element of _module_.[[RequestedModules]], do
           1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
           1. NOTE: Instantiate must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
-          1. Set _index_ to ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_).
+          1. If _requiredModule_.[[Async]] is *true*, then
+            1. Set _index_ to ? InnerModuleEvaluationAsync(_requiredModule_, _stack_, _index_).
           1. Assert: _requiredModule_.[[Status]] is either `"evaluating"` or `"evaluated"`.
           1. Assert: _requiredModule_.[[Status]] is `"evaluating"` if and only if _requiredModule_ is in _stack_.
-          1. <ins>If _requiredModule_.[[Status]] is `"evaluated"`, and _requiredModule_.[[Async]] is *true*, then</ins>
-            1. <ins>Assert: _module_.[[Async]] is *true*.</ins>
-            1. <ins>Append _requiredModule_.[[EvaluationPromise]] to _asyncDependencies_.</ins>
+          1. If _requiredModule_.[[Status]] is `"evaluated"`, then
+            1. If _requiredModule_.[[Async]] is *true*, then
+              1. Append _requiredModule_ to _asyncDependencies_.
+            1. Otherwise,
+              1. Append _requiredModule_ to _syncDependencies_.
           1. If _requiredModule_.[[Status]] is `"evaluating"`, then
             1. Assert: _requiredModule_ is a Cyclic Module Record.
             1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
-        1. <ins>If _module_.[[Async]] is *false*, then</ins>
-          1. Perform ? _module_.ExecuteModule()
-        1. <ins>Otherwise,</ins>
-          1. <ins>Let _capability_ be ! NewPromiseCapability(%Promise%).</ins>
-          1. <ins>Set _module_.[[EvaluationPromise]] to _capability_.[[Promise]].</ins>
-          1. <ins>Perform ! ExecuteModuleWhenImportsReady(_module_, _asyncDependencies_, _capability_).</ins>
+        1. Let _capability_ be ! NewPromiseCapability(%Promise%).
+        1. Set _module_.[[EvaluationPromise]] to _capability_.[[Promise]].
+        1. Perform ! ExecuteModuleWhenAsyncImportsReady(_module_, _asyncDependencies_, _syncDependencies_, _capability_).
         1. Assert: _module_ occurs exactly once in _stack_.
         1. Assert: _module_.[[DFSAncestorIndex]] is less than or equal to _module_.[[DFSIndex]].
         1. If _module_.[[DFSAncestorIndex]] equals _module_.[[DFSIndex]], then
@@ -476,8 +485,8 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
             1. Remove the last element of _stack_.
             1. Set _requiredModule_.[[Status]] to `"evaluated"`.
             1. If _requiredModule_ and _module_ are the same Module Record, set _done_ to *true*.
-            1. <ins>Otherwise, if _module_.[[Async]] is *true*,</ins>
-              1. <ins>Set _requiredModule_.[[EvaluationPromise]] to _module_.[[EvaluationPromise]].</ins>
+            1. Otherwise, if _module_.[[Async]] is *true*,
+              1. Set _requiredModule_.[[EvaluationPromise]] to _module_.[[EvaluationPromise]].
         1. Return _index_.
       </emu-alg>
       <emu-note>
@@ -485,36 +494,115 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
       </emu-note>
     </emu-clause>
 
-  <emu-clause id="sec-execute-module-when-imports-ready" aoid="ExecuteModuleWhenImportsReady">
-    <h1><ins>ExecuteModuleWhenImportsReady( _module_, _promises_, _capability_ )</ins></h1>
-    <emu-alg>
-      1. If _promises_ is an empty List,
-        1. Assert: _module_.[[ModuleAsync]] is *true*.
-        1. Perform ! _module_.ExecuteModule(_capability_).
+    <emu-clause id="sec-innermoduleevaluation" aoid="InnerModuleEvaluation">
+      <h1>InnerModuleEvaluation( _module_, _stack_, _index_ )</h1>
+
+      <p>The InnerModuleEvaluationSync abstract operation is used by Evaluate to perform the actual evaluation process for the <ins>synchronous</ins> Cyclic Module Record _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSIndex]] and [[DFSAncestoreIndex]] fields, are used the same way as in InnerModuleInstantiation.</p>
+
+      <p>This abstract operation performs the following steps:</p>
+
+      <emu-alg>
+        1. If _module_ is not a Source Text Module Record, then
+          1. Perform _module_.Evaluate().
+          1. Return _index_.
+        1. <ins>Assert: _module_.[[Async]] is *false*.</ins>
+        1. If _module_.[[Status]] is `"evaluated"`, then
+          1. If _module_.[[EvaluationError]] is *undefined*, return _index_.
+          1. Otherwise return _module_.[[EvaluationError]].
+        1. If _module_.[[Status]] is `"evaluating"`, return _index_.
+        1. Assert: _module_.[[Status]] is `"instantiated"`.
+        1. Set _module_.[[Status]] to `"evaluating"`.
+        1. Set _module_.[[DFSIndex]] to _index_.
+        1. Set _module_.[[DFSAncestorIndex]] to _index_.
+        1. Set _index_ to _index_ + 1.
+        1. Append _module_ to _stack_.
+        1. For each String _required_ that is an element of _module_.[[RequestedModules]], do
+          1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
+          1. NOTE: Instantiate must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
+          1. Set _index_ to ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_).
+          1. Assert: _requiredModule_.[[Status]] is either `"evaluating"` or `"evaluated"`.
+          1. Assert: _requiredModule_.[[Status]] is `"evaluating"` if and only if _requiredModule_ is in _stack_.
+          1. If _requiredModule_.[[Status]] is `"evaluating"`, then
+            1. Assert: _requiredModule_ is a Cyclic Module Record.
+            1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
+          1. Perform ? _module_.ExecuteModule().
+        1. Assert: _module_ occurs exactly once in _stack_.
+        1. Assert: _module_.[[DFSAncestorIndex]] is less than or equal to _module_.[[DFSIndex]].
+        1. If _module_.[[DFSAncestorIndex]] equals _module_.[[DFSIndex]], then
+          1. Let _done_ be *false*.
+          1. Repeat, while _done_ is *false*,
+            1. Let _requiredModule_ be the last element in _stack_.
+            1. Remove the last element of _stack_.
+            1. Set _requiredModule_.[[Status]] to `"evaluated"`.
+            1. If _requiredModule_ and _module_ are the same Module Record, set _done_ to *true*.
+        1. Return _index_.
+      </emu-alg>
+      <emu-note>
+        <p>A module is `"evaluating"` while it is being traversed by InnerModuleEvaluation. A module is `"evaluated"` when ModuleExecution has been called, even if that module execution is a promise that has not yet resolved.</p>
+      </emu-note>
+    </emu-clause>
+
+    <emu-clause id="sec-execute-module-when-async-imports-ready" aoid="ExecuteModuleWhenAsyncImportsReady">
+      <h1><ins>ExecuteModuleWhenAsyncImportsReady( _module_, _asyncDependencies_, _syncDependencies_, _capability_ )</ins></h1>
+      <emu-alg>
+        1. If _asyncDependencies_ is an empty List,
+          1. Assert: _module_.[[ModuleAsync]] is *true*.
+          1. Perform ! ExecuteAsyncModule(_module, _syncDependencies_, _capability_).
+          1. Return.
+        1. Let _index_ be 0.
+        1. Let _fullfilledCount_ be 0.
+        1. Let _total_ be the length of the List _promises_.
+        1. For each Module _module_ in _asyncDependencies_, do
+          1. Assert: _module_.[[EvaluationPromise]] is a Promise.
+          1. Let _promise_ be _module_.[[EvaluationPromise]].
+          1. Let _stepsFulfilled_ be the following steps with argument _arg_
+            1. Assert: _arg_ is *undefined*.
+            1. Set _fulfilledCount_ to _fulfilledCount_ + 1.
+            1. If _fulfilledCount_ is equal to _total_, then
+              1. Perform ! ExecuteAsyncModule(_module_, _syncDependencies_, _capability_).
+          1. Let _onFulfilled_ be CreateBuiltinFunction(_stepsFulfilled_).
+          1. Let _stepsReject_ be the following steps with argument _arg_
+            1. Perform ! Call(_capability_.[[Reject]], *undefined*, &laquo;_arg_&raquo;).
+          1. Let _onReject_ be CreateBuiltinFunction(_stepsReject_).
+          1. Perform ! PerformPromiseThen(_promise_, _onFulfilled_, _onRejected_).
         1. Return.
-      1. Let _index_ be 0.
-      1. Let _fullfilledCount_ be 0.
-      1. Let _total_ be the length of the List _promises_.
-      1. For each Promise _promise_ in _promises_, do
-        1. Let _stepsFulfilled_ be the following steps with argument _arg_
-          1. Assert: _arg_ is *undefined*.
-          1. Set _fulfilledCount_ to _fulfilledCount_ + 1.
-          1. If _fulfilledCount_ is equal to _total_, then
-            1. If _module_.[[ModuleAsync]] is *true*, then
-              1. Perform ! _module_.ExecuteModule(_capability_).
-            1. Otherwise,
-              1. Let _result_ be _module_.ExecuteModule().
-              1. If _result_ is a normal completion, then
-                1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo;*undefined*&raquo;).
-              1. Otherwise,
-                1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo;_result_.[[Value]]&raquo;).
-        1. Let _onFulfilled_ be CreateBuiltinFunction(_stepsFulfilled_).
-        1. Let _stepsReject_ be the following steps with argument _arg_
-          1. Perform ! Call(_capability_.[[Reject]], *undefined*, &laquo;_arg_&raquo;).
-        1. Let _onReject_ be CreateBuiltinFunction(_stepsReject_).
-        1. Perform ! PerformPromiseThen(_promise_, _onFulfilled_, _onRejected_).
-      1. Return.
-    </emu-alg>
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-execute-async-module" aoid="ExecuteAsyncModule">
+      <h1><ins>ExecuteAsyncModule( _module_, _syncDependencies_, _capability_ )</ins></h1>
+      <emu-alg>
+        1. Assert: _module_.[[Async]] is *true*.
+        1. For each Module _module_ in _syncDependencies_, do
+          1. Assert: _module_.[[Async]] is *false*.
+          1. Note: It is possible for synchronous dependencies to have already been executed by other top-level initiators.
+          1. If _module_.[[Status]] is `"instantiated"`, then
+            1. Let _stack_ be a new empty List.
+            1. Let _result_ be InnerModuleEvaluation(_module_, _stack_, 0).
+            1. If _result_ is an abrupt completion, then
+              1. For each module _m_ in _stack_, do
+                1. Assert: _m_.[[Status]] is `"evaluating"`.
+                1. Set _m_.[[Status]] to `"evaluated"`.
+                1. Set _m_.[[EvaluationError]] to _result_.
+              1. Assert: _module_.[[Status]] is `"evaluated"` and _module_.[[EvaluationError]] is _result_.
+              1. Perform ! Call(_capability_.[[Reject]], *undefined*, &laquo;_result_.[[Value]]&raquo;).
+              1. Return.
+            1. Assert _stack_ is empty.
+          1. Otherwise,
+            1. Assert: _module_.[[Status]] is `"evaluated"`.
+            1. If _module_.[[EvaluationError]] is not *undefined*, then
+              1. Perform ! Call(_capability_.[[Reject]], *undefined*, &laquo;_result_.[[Value]]&raquo;).
+              1. Return.
+        1. If _module_.[[ModuleAsync]] is *true*, then
+          1. Perform ! _module_.ExecuteModule(_capability_).
+        1. Otherwise,
+          1. Let _result_ be _module_.ExecuteModule().
+          1. If _result_ is a normal completion, then
+            1. Perform ! Call(_capability_.[[Resolve]], *undefined*, &laquo;*undefined*&raquo;).
+          1. Otherwise,
+            1. Perform ! Call(_capability_.[[Reject]], *undefined*, &laquo;_result_.[[Value]]&raquo;).
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 </emu-clause>
 


### PR DESCRIPTION
This resolves #63 and #64 by implementing two architectural changes:
1. Synchronous dependencies are always executed after asynchronous dependencies. And to achieve this, they are treated like their own top-level sync execution job. This works out because the sync subgraphs can be fully separated from an execution perspective just fine, and instead evaluated "just in time".
2. While the module bodies execute as a promise, the stitching together of module executions no longer relies on promises but instead on execution handler listeners.

Instead of changing `InnerModuleEvaluation`, it is left exactly as it was. Then we create a new `InnerModuleEvaluationAsync` that acts specifically on async module graphs. We then separately collect "asyncDependencies" and "syncDependencies", where the new algorithm is to wait on the async dependencies, then execute the sync dependencies in order, immediately followed by synchronously executing the module itself, thus retaining the property that sync chains remain sync even when a new async dependency is added (exactly supporting the case described in https://github.com/tc39/proposal-top-level-await/issues/64#issuecomment-488713754).

That still leaves the following case:

A.js
```js
import './B.js';
console.log('four');
```

B.js
```js
import './c.js';
import './D.js';
console.log('three');
```

c.js
```js
console.log('two');
```

D.js
```js
await Promise.resolve();
console.log('one');
```

Where in the above the logs will appear in order, with synchronous execution happening between "two" and "three", but not "three" and "four".

To get synchonous execution between "three" and "four" in the above, we need to ensure that an AsyncModule with a synchonous module body importing a synchronous module remains synchronous. And to do this, we update the dependency fulfillment to use execution task handlers over promises.