### PR TITLE
Refactor ensuring sync parent execution

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -141,13 +141,13 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
       </tr>
       <tr>
         <td>
-          <ins>[[EvaluationPromise]]</ins>
+          <ins>[[EvaluationCapability]]</ins>
         </td>
         <td>
-          <ins>*undefined* | Promise</ins>
+          <ins>*undefined* | PromiseCapability</ins>
         </td>
         <td>
-          <ins>If [[Async]] is true, and evaluation of this module has begun, this field stores a Promise that resolves or rejects when evaluation of the module is complete.</ins>
+          <ins>If [[Async]] is true, and evaluation of this module has begun, this field stores a PromiseCapability that resolves or rejects when evaluation of the module is complete.</ins>
         </td>
       </tr>
       </tbody>
@@ -292,6 +292,39 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
             <ins>Whether this module is individually asynchronous. A module may have [[Async]] *true* and [[ModuleAsync]] *false* if dependencies are asynchronous, but this module is not. This field must not change after the module is parsed.</ins>
           </td>
         </tr>
+        <tr>
+          <td>
+            <ins>[[AsyncParentModules]]</ins>
+          </td>
+          <td>
+            <ins>List of Cyclic Module Record | *undefined*</ins>
+          </td>
+          <td>
+            <ins>If [[Async]] is true and execution has started, this tracks the parent importers of this module for the top-level execution job.</ins>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <ins>[[DirectEvaluationCapability]]</ins>
+          </td>
+          <td>
+            <ins>Promise Capability Record | *undefined*</ins>
+          </td>
+          <td>
+            <ins>If [[Async]] is true and execution has started, this tracks the direct execution promise for the module.</ins>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <ins>[[PendingAsyncDependencies]]</ins>
+          </td>
+          <td>
+            <ins>Integer | *undefined*</ins>
+          </td>
+          <td>
+            <ins>If [[Async]] is true and execution has started, this tracks the number of async dependency modules remaining to execute for this module.</ins>
+          </td>
+        </tr>
       </tbody>
     </table>
   </emu-table>
@@ -416,7 +449,6 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
       1. If _result_ is an abrupt completion, then
         1. For each module _m_ in _stack_, do
           1. Assert: _m_.[[Status]] is `"evaluating"`.
-          1. <ins>If _m_.[[Async]] is *true*, return _result_.</ins>
           1. Set _m_.[[Status]] to `"evaluated"`.
           1. Set _m_.[[EvaluationError]] to _result_.
         1. Assert: _module_.[[Status]] is `"evaluated"` and _module_.[[EvaluationError]] is _result_.
@@ -452,21 +484,27 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. For each String _required_ that is an element of _module_.[[RequestedModules]], do
           1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
           1. NOTE: Instantiate must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
-          1. Set _index_ to ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_).
+          1. <ins>If _requiredModule_.[[Async]] is *true* and _asyncDependencies_ does not contain _requiredModule_, then</ins>
+            1. <ins>Append _requiredModule_ to _asyncDependencies_.</ins>
+            1. <ins>Append _module_ to _requiredModule_.[[AsyncParentModules]].</ins>
+          1. <ins>If _module_.[[Async]] is *false* or _requiredModule_.[[Async]] is *true*, then</ins>
+            1. <ins>Note: Synchronous dependencies of async modules have their execution deferred until after async dependencies have completed.</ins>
+            1. Set _index_ to ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_).
           1. Assert: _requiredModule_.[[Status]] is either `"evaluating"` or `"evaluated"`.
           1. Assert: _requiredModule_.[[Status]] is `"evaluating"` if and only if _requiredModule_ is in _stack_.
-          1. <ins>If _requiredModule_.[[Status]] is `"evaluated"`, and _requiredModule_.[[Async]] is *true*, then</ins>
-            1. <ins>Assert: _module_.[[Async]] is *true*.</ins>
-            1. <ins>Append _requiredModule_.[[EvaluationPromise]] to _asyncDependencies_.</ins>
           1. If _requiredModule_.[[Status]] is `"evaluating"`, then
             1. Assert: _requiredModule_ is a Cyclic Module Record.
             1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
         1. <ins>If _module_.[[Async]] is *false*, then</ins>
           1. Perform ? _module_.ExecuteModule()
         1. <ins>Otherwise,</ins>
+          1. <ins>Set _module_.[[AsyncParentModules]] to a new empty List.</ins>
+          1. <ins>Set _module_.[[PendingAsyncDependencies]] to the length of _asyncDependencies_.</ins>
           1. <ins>Let _capability_ be ! NewPromiseCapability(%Promise%).</ins>
-          1. <ins>Set _module_.[[EvaluationPromise]] to _capability_.[[Promise]].</ins>
-          1. <ins>Perform ! ExecuteModuleWhenImportsReady(_module_, _asyncDependencies_, _capability_).</ins>
+          1. <ins>Set _module_.[[DirectEvaluationCapability]] to _capability_.</ins>
+          1. <ins>Set _module_.[[EvaluationCapability]] to _capability_.</ins>
+          1. <ins>If the length of _asyncDependencies_ is 0, then</ins>
+            1. <ins>Perform ! ExecuteSyncDependenciesAndModule(_module_).</ins>
         1. Assert: _module_ occurs exactly once in _stack_.
         1. Assert: _module_.[[DFSAncestorIndex]] is less than or equal to _module_.[[DFSIndex]].
         1. If _module_.[[DFSAncestorIndex]] equals _module_.[[DFSIndex]], then
@@ -477,7 +515,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
             1. Set _requiredModule_.[[Status]] to `"evaluated"`.
             1. If _requiredModule_ and _module_ are the same Module Record, set _done_ to *true*.
             1. <ins>Otherwise, if _module_.[[Async]] is *true*,</ins>
-              1. <ins>Set _requiredModule_.[[EvaluationPromise]] to _module_.[[EvaluationPromise]].</ins>
+              1. <ins>Set _requiredModule_.[[EvaluationCapability]] to _module_.[[EvaluationCapability]].</ins>
         1. Return _index_.
       </emu-alg>
       <emu-note>
@@ -485,36 +523,47 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
       </emu-note>
     </emu-clause>
 
-  <emu-clause id="sec-execute-module-when-imports-ready" aoid="ExecuteModuleWhenImportsReady">
-    <h1><ins>ExecuteModuleWhenImportsReady( _module_, _promises_, _capability_ )</ins></h1>
-    <emu-alg>
-      1. If _promises_ is an empty List,
-        1. Assert: _module_.[[ModuleAsync]] is *true*.
-        1. Perform ! _module_.ExecuteModule(_capability_).
-        1. Return.
-      1. Let _index_ be 0.
-      1. Let _fullfilledCount_ be 0.
-      1. Let _total_ be the length of the List _promises_.
-      1. For each Promise _promise_ in _promises_, do
-        1. Let _stepsFulfilled_ be the following steps with argument _arg_
-          1. Assert: _arg_ is *undefined*.
-          1. Set _fulfilledCount_ to _fulfilledCount_ + 1.
-          1. If _fulfilledCount_ is equal to _total_, then
-            1. If _module_.[[ModuleAsync]] is *true*, then
-              1. Perform ! _module_.ExecuteModule(_capability_).
-            1. Otherwise,
-              1. Let _result_ be _module_.ExecuteModule().
-              1. If _result_ is a normal completion, then
-                1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo;*undefined*&raquo;).
-              1. Otherwise,
-                1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo;_result_.[[Value]]&raquo;).
-        1. Let _onFulfilled_ be CreateBuiltinFunction(_stepsFulfilled_).
-        1. Let _stepsReject_ be the following steps with argument _arg_
-          1. Perform ! Call(_capability_.[[Reject]], *undefined*, &laquo;_arg_&raquo;).
-        1. Let _onReject_ be CreateBuiltinFunction(_stepsReject_).
-        1. Perform ! PerformPromiseThen(_promise_, _onFulfilled_, _onRejected_).
-      1. Return.
-    </emu-alg>
+    <emu-clause id="sec-execute-sync-dependencies-and-module" aoid="ExecuteSyncDependenciesAndModule">
+      <h1><ins>ExecuteSyncDependenciesAndModule (_module_)</ins></h1>
+      <emu-alg>
+        1. Assert: _module_.[[Async]] is *true*.
+        1. For each String _required_ that is an element of _module_.[[RequestedModules]], do
+          1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
+          1. If _requiredModule_.[[Async]] is *false* and _requiredModule_.[[Status]] is not `"evaluated"`, then
+            1. Let _result_ be _module_.Evaluate().
+            1. If _result_ is an abrupt completion, then
+              1. Perform ! Call(_module_.[[DirectEvaluationCapability]].[[Reject]], *undefined*, &laquo;_result_.[[Value]]&raquo;).
+              1. Return *undefined*.
+        1. Perform ! _module_.ExecuteModule(_module_.[[DirectEvaluationCapability]]).
+        1. Return *undefined*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-executionfulfilled" aoid="AsyncExecutionFulfilled">
+      <h1><ins>AsyncExecutionFulfilled ()</ins></h1>
+      <emu-alg>
+        1. Let _f_ be the active function object.
+        1. Let _module_ be _f_.[[Module]].
+        1. For each Module _m_ of _module_.[[AsyncParentModules]], do
+          1. Decrement _m_.[[PendingAsyncDependencies]] by 1.
+          1. If _m_.[[PendingAsyncDependencies]] is 0 and _m_.[[EvaluationError]] is *undefined*, then
+            1. Perform ! ExecuteSyncDependenciesAndModule(_m_).
+        1. Return *undefined*.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-executionrejected" aoid="AsyncExecutionRejected">
+      <h1><ins>AsyncExecutionRejected ( _error_ )</ins></h1>
+      <emu-alg>
+        1. Let _f be the active function object.
+        1. Let _module_ be _f_.[[Module]].
+        1. For each Module _m_ of _module_.[[AsyncParentModules]], do
+          1. If _m_.[[EvaluationError]] is *undefined*, then
+            1. Set _m_.[[EvaluationError]] to ThrowCompletion(_error_).
+            1. Perform ! Call(_m_.[[DirectEvaluationCapability]].[[Reject]], *undefined*, &laquo;_error_&raquo;).
+        1. Return *undefined*.
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 </emu-clause>
 
@@ -551,7 +600,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. Else,
           1. Append _ee_ to _indirectExportEntries_.
       1. <ins>Let _async_ be _body_ Contains |AwaitExpression|.</ins>
-      1. Return Source Text Module Record { [[Realm]]: _realm_, [[Environment]]: *undefined*, [[Namespace]]: *undefined*, <ins>[[EvaluationPromise]]: *undefined*, </ins>[[Status]]: `"uninstantiated"`, [[EvaluationError]]: *undefined*, [[HostDefined]]: _hostDefined_, [[ECMAScriptCode]]: _body_, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[DFSIndex]]: *undefined*, [[DFSAncestorIndex]]: *undefined*, <ins>[[Async]]: _async_, [[ModuleAsync]]: _async_</ins> }.
+      1. Return Source Text Module Record { [[Realm]]: _realm_, [[Environment]]: *undefined*, [[Namespace]]: *undefined*, <ins>[[Async]]: _async_, [[EvaluationCapability]]: *undefined*, [[DirectEvaluationCapability]]: *undefined*, [[AsyncParentModules]]: *undefined*, [[PendingAsyncDependencies]]: *undefined*, </ins>[[Status]]: `"uninstantiated"`, [[EvaluationError]]: *undefined*, [[HostDefined]]: _hostDefined_, [[ECMAScriptCode]]: _body_, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[DFSIndex]]: *undefined*, [[DFSAncestorIndex]]: *undefined*, <ins>[[ModuleAsync]]: _async_</ins> }.
     </emu-alg>
     <emu-note>
       <p>An implementation may parse module source text and analyse it for Early Error conditions prior to the evaluation of ParseModule for that module source text. However, the reporting of any errors must be deferred until the point where this specification actually performs ParseModule upon that source text.</p>
@@ -584,6 +633,13 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. <ins>Otherwise,</ins>
           1. <ins>Assert: _capability_ was provided.</ins>
           1. <ins>Perform ! AsyncBlockStart(_capability_, _module_.[[ECMAScriptCode]], _moduleCxt_).</ins>
+          1. <ins>Let _stepsFulfilled_ be the steps of _AsyncExecutionFulfilled_.</ins>
+          1. <ins>Let _onFulfilled_ be CreateBuiltinFunction(_stepsFulfilled_, &laquo; [[Module]] &raquo;).</ins>
+          1. <ins>Set _onFulfilled_.[[Module]] to _module_.</ins>
+          1. <ins>Let _stepsRejected_ be the steps of _AsyncExecutionRejected_.</ins>
+          1. <ins>Let _onRejected_ be CreateBuiltinFunction(_stepsRejected_, &laquo; [[Module]] &raquo;).</ins>
+          1. <ins>Set _onRejected_.[[Module]] to _module_.</ins>
+          1. <ins>Perform ! PerformPromiseThen(_capability_.[[Promise]], _onFulfilled_, _onRejected_).</ins>
           1. <ins>Return.</ins>
       </emu-alg>
     </emu-clause>


### PR DESCRIPTION
This resolves #64 ensuring that the execution of synchronous modules, whose execution can only begin after deeper asynchronous dependencies have already completed, remains synchronous with their parent modules.

This ensures that adding an asynchronous dependency to a module does not change the execution of that module which could be a source of bugs during application development - adding a new and unrelated dependency should not change the timing of the modules already in the graph.

Consider the following example:

main.js
```js
import './a.js';
import './b.js';
console.log('main');
```

where a.js contains:
```js
console.log('a');
Promise.resolve().then(() => {
  console.log('a task');
});
```

and identically for b.js.

On execution we get "a", "b", "main" synchronously in order, followed by "a task" then "b task".

Now if we introduce a new dependency to this application which is async:

main.js
```js
import './a.js';
import './b.js';
import './async.js';
console.log('main');
```

with async.js containing:

```js
console.log('async start');
await new Promise(resolve => setImmediate(resolve));
console.log('async end');
```

where async.js contains a top-level await, the entire execution timing changes to instead read - "a", "b", "a task", "b task", "async start", "async end", "main".

The issue here is that introducing a dependency can now alter the interrelated timings of existing modules, which may introduce execution bugs. Typically we don't think of introducing a dependency as something that can drastically change the execution semantics of our existing code! This effect is also viral in that all modules importing this "main" file will also have microtasks now being run on their individual completions too. No module can execute synchronously with main anymore.

The approach taken in this PR is to defer the execution of synchronous dependencies to happen after the async modules have resolved, instead of immediately.

The result is that in the example above we get the following execution - "async start", "async end", "a", "b", "main", where the execution of "a", "b", "main" remains identical in semantics to the execution of "a", "b", "main" before we added the asynchronous dependency. In addition all parent importers of main will continue to execute according to their previous execution timing as well, avoiding the execution timing difference propagating up al modules in the graph. What this means is that introducing an asynchronous dependency will no longer risk drastically changing the execution semantics of our existing code from as it was before we added the asynchronous dependency.

The final approach turned out to be quite simple to implement.Circular references and error handling invariants are maintained in that cycles transition through all states together, and errors stop further execution of synchronous modules, while also throwing into both sync and async cycles as a single strongly connected component transition.