### PR TITLE
Parent execution revision

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -141,13 +141,13 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
       </tr>
       <tr>
         <td>
-          <ins>[[EvaluationPromise]]</ins>
+          <ins>[[EvaluationCapability]]</ins>
         </td>
         <td>
-          <ins>*undefined* | Promise</ins>
+          <ins>*undefined* | PromiseCapability</ins>
         </td>
         <td>
-          <ins>If [[Async]] is true, and evaluation of this module has begun, this field stores a Promise that resolves or rejects when evaluation of the module is complete.</ins>
+          <ins>If [[Async]] is true, and evaluation of this module has begun, this field stores a PromiseCapability that resolves or rejects when evaluation of the module is complete.</ins>
         </td>
       </tr>
       </tbody>
@@ -292,6 +292,39 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
             <ins>Whether this module is individually asynchronous. A module may have [[Async]] *true* and [[ModuleAsync]] *false* if dependencies are asynchronous, but this module is not. This field must not change after the module is parsed.</ins>
           </td>
         </tr>
+        <tr>
+          <td>
+            <ins>[[AsyncParentModules]]</ins>
+          </td>
+          <td>
+            <ins>List of Cyclic Module Record | *undefined*</ins>
+          </td>
+          <td>
+            <ins>If [[Async]] is true and execution has started, this tracks the parent importers of this module for the top-level execution job.</ins>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <ins>[[DirectEvaluationCapability]]</ins>
+          </td>
+          <td>
+            <ins>Promise Capability Record | *undefined*</ins>
+          </td>
+          <td>
+            <ins>If [[Async]] is true and execution has started, this tracks the direct execution promise for the module.</ins>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <ins>[[PendingAsyncDependencies]]</ins>
+          </td>
+          <td>
+            <ins>Integer | *undefined*</ins>
+          </td>
+          <td>
+            <ins>If [[Async]] is true and execution has started, this tracks the number of async dependency modules remaining to execute for this module.</ins>
+          </td>
+        </tr>
       </tbody>
     </table>
   </emu-table>
@@ -349,7 +382,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
           1. Set _m_.[[DFSAncestorIndex]] to *undefined*.
         1. Assert: _module_.[[Status]] is `"uninstantiated"`.
         1. Return _result_.
-      1. Assert: _module_.[[Status]] is `"instantiated"` or `"evaluated"`.
+      1. Assert: _module_.[[Status]] is `"instantiated"`<ins>, `"evaluating-async"`</ins> or `"evaluated"`.
       1. Assert: _stack_ is empty.
       1. Return *undefined*.
     </emu-alg>
@@ -365,7 +398,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. If _module_ is not a Cyclic Module Record, then
           1. Perform ? _module_.Instantiate().
           1. Return _index_.
-        1. If _module_.[[Status]] is `"instantiating"`, `"instantiated"`, or `"evaluated"`, then
+        1. If _module_.[[Status]] is `"instantiating"`, `"instantiated"`, <ins>`"evaluating-async"`</ins> or `"evaluated"`, then
           1. Return _index_.
         1. Assert: _module_.[[Status]] is `"uninstantiated"`.
         1. Set _module_.[[Status]] to `"instantiating"`.
@@ -376,7 +409,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. For each String _required_ that is an element of _module_.[[RequestedModules]], do
           1. Let _requiredModule_ be ? HostResolveImportedModule(_module_, _required_).
           1. Set _index_ to ? InnerModuleInstantiation(_requiredModule_, _stack_, _index_).
-          1. Assert: _requiredModule_.[[Status]] is either `"instantiating"`, `"instantiated"`, or `"evaluated"`.
+          1. Assert: _requiredModule_.[[Status]] is either `"instantiating"`, `"instantiated"`, <ins>`"evaluating-async"`</ins> or `"evaluated"`.
           1. Assert: _requiredModule_.[[Status]] is `"instantiating"` if and only if _requiredModule_ is in _stack_.
           1. If _requiredModule_.[[Status]] is `"instantiating"`, then
             1. Assert: _requiredModule_ is a Cyclic Module Record.
@@ -402,7 +435,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
     <h1>Evaluate ( ) Concrete Method</h1>
 
     <p>The Evaluate concrete method of a Cyclic Module Record implements the corresponding Module Record abstract method.</p>
-    <p>Evaluate transitions this module's [[Status]] from `"instantiated"` to `"evaluated"`.</p>
+    <p>Evaluate transitions this module's [[Status]] from `"instantiated"` to `"evaluated"`<ins> or `"evaluating-async"`</ins>.</p>
 
     <p>If execution results in a <ins>synchronous</ins> exception, that exception is recorded in the [[EvaluationError]] field and rethrown by future invocations of Evaluate.</p>
 
@@ -410,18 +443,17 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
 
     <emu-alg>
       1. Let _module_ be this Source Text Module Record.
-      1. Assert: _module_.[[Status]] is `"instantiated"` or `"evaluated"`.
+      1. Assert: _module_.[[Status]] is `"instantiated"`, <ins>`"evaluating-async"`</ins> or `"evaluated"`.
       1. Let _stack_ be a new empty List.
       1. Let _result_ be InnerModuleEvaluation(_module_, _stack_, 0).
       1. If _result_ is an abrupt completion, then
         1. For each module _m_ in _stack_, do
           1. Assert: _m_.[[Status]] is `"evaluating"`.
-          1. <ins>If _m_.[[Async]] is *true*, return _result_.</ins>
           1. Set _m_.[[Status]] to `"evaluated"`.
           1. Set _m_.[[EvaluationError]] to _result_.
         1. Assert: _module_.[[Status]] is `"evaluated"` and _module_.[[EvaluationError]] is _result_.
         1. Return _result_.
-      1. Assert: _module_.[[Status]] is `"evaluated"` and _module_.[[EvaluationError]] is *undefined*.
+      1. Assert: _module_.[[Status]] is `"evaluated"`<ins> or `"evaluating-async"`</ins> and _module_.[[EvaluationError]] is *undefined*.
       1. Assert: _stack_ is empty.
       1. <ins>If _module_.[[Async]] is *true*, return _module_.[[EvaluationPromise]].</ins>
       1. <ins>Otherwise</ins>, return *undefined*.
@@ -438,7 +470,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. If _module_ is not a Source Text Module Record, then
           1. Perform _module_.Evaluate().
           1. Return _index_.
-        1. If _module_.[[Status]] is `"evaluated"`, then
+        1. If _module_.[[Status]] is `"evaluated"` <ins> or `"evaluating-async"`</ins>, then
           1. If _module_.[[EvaluationError]] is *undefined*, return _index_.
           1. Otherwise return _module_.[[EvaluationError]].
         1. If _module_.[[Status]] is `"evaluating"`, return _index_.
@@ -448,25 +480,29 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. Set _module_.[[DFSAncestorIndex]] to _index_.
         1. Set _index_ to _index_ + 1.
         1. Append _module_ to _stack_.
-        1. <ins>Let _asyncDependencies_ be an empty List.</ins>
+        1. <ins>Let _pendingAsyncDependencies_ be an empty List.</ins>
         1. For each String _required_ that is an element of _module_.[[RequestedModules]], do
           1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
           1. NOTE: Instantiate must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
+          1. <ins>If _requiredModule_.[[Async]] is *true*, _requiredModule_.[[Status]] is not `"evaluated"` and _pendingAsyncDependencies_ does not contain _requiredModule_, then</ins>
+            1. <ins>Append _requiredModule_ to _pendingAsyncDependencies_.</ins>
+            1. <ins>Append _module_ to _requiredModule_.[[AsyncParentModules]].</ins>
           1. Set _index_ to ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_).
-          1. Assert: _requiredModule_.[[Status]] is either `"evaluating"` or `"evaluated"`.
+          1. Assert: _requiredModule_.[[Status]] is either `"evaluating"` <ins>`"evaluating-async"`</ins> or `"evaluated"`.
           1. Assert: _requiredModule_.[[Status]] is `"evaluating"` if and only if _requiredModule_ is in _stack_.
-          1. <ins>If _requiredModule_.[[Status]] is `"evaluated"`, and _requiredModule_.[[Async]] is *true*, then</ins>
-            1. <ins>Assert: _module_.[[Async]] is *true*.</ins>
-            1. <ins>Append _requiredModule_.[[EvaluationPromise]] to _asyncDependencies_.</ins>
           1. If _requiredModule_.[[Status]] is `"evaluating"`, then
             1. Assert: _requiredModule_ is a Cyclic Module Record.
             1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
         1. <ins>If _module_.[[Async]] is *false*, then</ins>
           1. Perform ? _module_.ExecuteModule()
         1. <ins>Otherwise,</ins>
+          1. <ins>Set _module_.[[AsyncParentModules]] to a new empty List.</ins>
+          1. <ins>Set _module_.[[PendingAsyncDependencies]] to the length of _pendingAsyncDependencies_.</ins>
           1. <ins>Let _capability_ be ! NewPromiseCapability(%Promise%).</ins>
-          1. <ins>Set _module_.[[EvaluationPromise]] to _capability_.[[Promise]].</ins>
-          1. <ins>Perform ! ExecuteModuleWhenImportsReady(_module_, _asyncDependencies_, _capability_).</ins>
+          1. <ins>Set _module_.[[DirectEvaluationCapability]] to _capability_.</ins>
+          1. <ins>Set _module_.[[EvaluationCapability]] to _capability_.</ins>
+          1. <ins>If the length of _pendingAsyncDependencies_ is 0, then</ins>
+            1. <ins>Perform ! _module_.ExecuteModule(_module_.[[DirectEvaluationCapability]]).</ins>
         1. Assert: _module_ occurs exactly once in _stack_.
         1. Assert: _module_.[[DFSAncestorIndex]] is less than or equal to _module_.[[DFSIndex]].
         1. If _module_.[[DFSAncestorIndex]] equals _module_.[[DFSIndex]], then
@@ -474,47 +510,53 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
           1. Repeat, while _done_ is *false*,
             1. Let _requiredModule_ be the last element in _stack_.
             1. Remove the last element of _stack_.
-            1. Set _requiredModule_.[[Status]] to `"evaluated"`.
+            1. <ins>If _module_.[[Async]] is *true*, set _requiredModule_.[[Status]] to `"evaluating-async"`.</ins>
+            1. <ins>Otherwise, </ins>set _requiredModule_.[[Status]] to `"evaluated"`.
             1. If _requiredModule_ and _module_ are the same Module Record, set _done_ to *true*.
             1. <ins>Otherwise, if _module_.[[Async]] is *true*,</ins>
-              1. <ins>Set _requiredModule_.[[EvaluationPromise]] to _module_.[[EvaluationPromise]].</ins>
+              1. <ins>Set _requiredModule_.[[EvaluationCapability]] to _module_.[[EvaluationCapability]].</ins>
         1. Return _index_.
       </emu-alg>
       <emu-note>
-        <p>A module is `"evaluating"` while it is being traversed by InnerModuleEvaluation. A module is `"evaluated"` when ModuleExecution has been called, even if that module execution is a promise that has not yet resolved.</p>
+        <p>A module is `"evaluating"` while it is being traversed by InnerModuleEvaluation. A module is `"evaluated"` on execution completion, and `"evaluating-async"` during execution if it is an asynchronous module.</p>
       </emu-note>
     </emu-clause>
 
-  <emu-clause id="sec-execute-module-when-imports-ready" aoid="ExecuteModuleWhenImportsReady">
-    <h1><ins>ExecuteModuleWhenImportsReady( _module_, _promises_, _capability_ )</ins></h1>
-    <emu-alg>
-      1. If _promises_ is an empty List,
-        1. Assert: _module_.[[ModuleAsync]] is *true*.
-        1. Perform ! _module_.ExecuteModule(_capability_).
-        1. Return.
-      1. Let _index_ be 0.
-      1. Let _fullfilledCount_ be 0.
-      1. Let _total_ be the length of the List _promises_.
-      1. For each Promise _promise_ in _promises_, do
-        1. Let _stepsFulfilled_ be the following steps with argument _arg_
-          1. Assert: _arg_ is *undefined*.
-          1. Set _fulfilledCount_ to _fulfilledCount_ + 1.
-          1. If _fulfilledCount_ is equal to _total_, then
-            1. If _module_.[[ModuleAsync]] is *true*, then
-              1. Perform ! _module_.ExecuteModule(_capability_).
-            1. Otherwise,
-              1. Let _result_ be _module_.ExecuteModule().
-              1. If _result_ is a normal completion, then
-                1. Perform ! Call(_promiseCapability_.[[Resolve]], *undefined*, &laquo;*undefined*&raquo;).
-              1. Otherwise,
-                1. Perform ! Call(_promiseCapability_.[[Reject]], *undefined*, &laquo;_result_.[[Value]]&raquo;).
-        1. Let _onFulfilled_ be CreateBuiltinFunction(_stepsFulfilled_).
-        1. Let _stepsReject_ be the following steps with argument _arg_
-          1. Perform ! Call(_capability_.[[Reject]], *undefined*, &laquo;_arg_&raquo;).
-        1. Let _onReject_ be CreateBuiltinFunction(_stepsReject_).
-        1. Perform ! PerformPromiseThen(_promise_, _onFulfilled_, _onRejected_).
-      1. Return.
-    </emu-alg>
+    <emu-clause id="sec-executionfulfilled" aoid="AsyncExecutionFulfilled">
+      <h1><ins>AsyncExecutionFulfilled ()</ins></h1>
+      <emu-alg>
+        1. Let _f_ be the active function object.
+        1. Let _module_ be _f_.[[Module]].
+        1. Assert: _module_.[[Status]] is `"evaluating-async"`.
+        1. Set _module_.[[Status]] to `"evaluated"`.
+        1. For each Module _m_ of _module_.[[AsyncParentModules]], do
+          1. Decrement _m_.[[PendingAsyncDependencies]] by 1.
+          1. If _m_.[[PendingAsyncDependencies]] is 0 and _m_.[[EvaluationError]] is *undefined*, then
+            1. Assert _m_.[[Status]] is `"evaluating-async"`.
+            1. Perform ! _module_.ExecuteModule(_module_.[[DirectEvaluationCapability]]).
+        1. Return *undefined*.
+      </emu-alg>
+      <emu-note>
+        <p>When propagating ExecuteModule calls up the parent stack through multiple AsyncExecutionFulfilled handlers, the execution context should not be changed apart from the direct execution of the modules being executed in the stack.</p>
+      </emu-note>
+    </emu-clause>
+
+    <emu-clause id="sec-executionrejected" aoid="AsyncExecutionRejected">
+      <h1><ins>AsyncExecutionRejected ( _error_ )</ins></h1>
+      <emu-alg>
+        1. Let _f be the active function object.
+        1. Let _module_ be _f_.[[Module]].
+        1. Assert: _module_.[[Status]] is `"evaluating-async"`.
+        1. Assert: _module_.[[EvaluationError]] is *undefined*.
+        1. Set _module_.[[Status]] to `"evaluated"`.
+        1. Set _module_.[[EvaluationError]] to ThrowCompletion(_error_).
+        1. For each Module _m_ of _module_.[[AsyncParentModules]], do
+          1. If _m_.[[Status]] is `"evaluating-async"`, then
+            1. Set _m_.[[EvaluationError]] to ThrowCompletion(_error_).
+            1. Perform ! Call(_m_.[[DirectEvaluationCapability]].[[Reject]], *undefined*, &laquo;_error_&raquo;).
+        1. Return *undefined*.
+      </emu-alg>
+    </emu-clause>
   </emu-clause>
 </emu-clause>
 
@@ -551,7 +593,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. Else,
           1. Append _ee_ to _indirectExportEntries_.
       1. <ins>Let _async_ be _body_ Contains |AwaitExpression|.</ins>
-      1. Return Source Text Module Record { [[Realm]]: _realm_, [[Environment]]: *undefined*, [[Namespace]]: *undefined*, <ins>[[EvaluationPromise]]: *undefined*, </ins>[[Status]]: `"uninstantiated"`, [[EvaluationError]]: *undefined*, [[HostDefined]]: _hostDefined_, [[ECMAScriptCode]]: _body_, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[DFSIndex]]: *undefined*, [[DFSAncestorIndex]]: *undefined*, <ins>[[Async]]: _async_, [[ModuleAsync]]: _async_</ins> }.
+      1. Return Source Text Module Record { [[Realm]]: _realm_, [[Environment]]: *undefined*, [[Namespace]]: *undefined*, <ins>[[Async]]: _async_, [[EvaluationCapability]]: *undefined*, [[DirectEvaluationCapability]]: *undefined*, [[AsyncParentModules]]: *undefined*, [[PendingAsyncDependencies]]: *undefined*, </ins>[[Status]]: `"uninstantiated"`, [[EvaluationError]]: *undefined*, [[HostDefined]]: _hostDefined_, [[ECMAScriptCode]]: _body_, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[DFSIndex]]: *undefined*, [[DFSAncestorIndex]]: *undefined*, <ins>[[ModuleAsync]]: _async_</ins> }.
     </emu-alg>
     <emu-note>
       <p>An implementation may parse module source text and analyse it for Early Error conditions prior to the evaluation of ParseModule for that module source text. However, the reporting of any errors must be deferred until the point where this specification actually performs ParseModule upon that source text.</p>
@@ -584,6 +626,13 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. <ins>Otherwise,</ins>
           1. <ins>Assert: _capability_ was provided.</ins>
           1. <ins>Perform ! AsyncBlockStart(_capability_, _module_.[[ECMAScriptCode]], _moduleCxt_).</ins>
+          1. <ins>Let _stepsFulfilled_ be the steps of _AsyncExecutionFulfilled_.</ins>
+          1. <ins>Let _onFulfilled_ be CreateBuiltinFunction(_stepsFulfilled_, &laquo; [[Module]] &raquo;).</ins>
+          1. <ins>Set _onFulfilled_.[[Module]] to _module_.</ins>
+          1. <ins>Let _stepsRejected_ be the steps of _AsyncExecutionRejected_.</ins>
+          1. <ins>Let _onRejected_ be CreateBuiltinFunction(_stepsRejected_, &laquo; [[Module]] &raquo;).</ins>
+          1. <ins>Set _onRejected_.[[Module]] to _module_.</ins>
+          1. <ins>Perform ! PerformPromiseThen(_capability_.[[Promise]], _onFulfilled_, _onRejected_).</ins>
           1. <ins>Return.</ins>
       </emu-alg>
     </emu-clause>
@@ -628,7 +677,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
 
     <p>Now consider a case where _A_ has an instantiation error; for example, it tries to import a binding from _C_ that does not exist. In that case, the above steps still occur, including the early return from the second call to InnerModuleInstantiation on _A_. However, once we unwind back to the original InnerModuleInstantiation on _A_, it fails during ModuleDeclarationEnvironmentSetup, namely right after _C_.ResolveExport(). The thrown *SyntaxError* exception propagates up to _A_.Instantiate, which resets all modules that are currently on its _stack_ (these are always exactly the modules that are still `"instantiating"`). Hence both _A_ and _B_ become `"uninstantiated"`. Note that _C_ is left as `"instantiated"`.</p>
 
-    <p>Finally, consider a case where _A_ has an evaluation error; for example, its source code throws an exception. In that case, the evaluation-time analog of the above steps still occurs, including the early return from the second call to InnerModuleEvaluation on _A_. However, once we unwind back to the original InnerModuleEvaluation on _A_, it fails by assumption. The exception thrown propagates up to _A_.Evaluate() <del>, which records the error in all modules that are currently on its _stack_ (i.e., the modules that are still `"evaluating"`)</del><ins>via Promise rejections, which form a chain through the whole dependency graph due to ExecuteModuleWhenImportsReady</ins>. Hence both _A_ and _B_ become `"evaluated"` and the exception is recorded in both _A_ and _B_'s <del>[[EvaluationError]]</del><ins>[[EvaluationResult]]</ins> fields, while _C_ is left as `"evaluated"` with <del>no [[EvaluationError]]</del><ins>its [[EvaluationResult]] set to *undefined*.</p>
+    <p>Finally, consider a case where _A_ has an evaluation error; for example, its source code throws an exception. In that case, the evaluation-time analog of the above steps still occurs, including the early return from the second call to InnerModuleEvaluation on _A_. However, once we unwind back to the original InnerModuleEvaluation on _A_, it fails by assumption. The exception thrown propagates up to _A_.Evaluate() <del>, which records the error in all modules that are currently on its _stack_ (i.e., the modules that are still `"evaluating"`)</del><ins>via Promise rejections, which form a chain through the whole dependency graph due to AsyncExecutionRejected handlers</ins>. Hence both _A_ and _B_ become `"evaluated"` and the exception is recorded in both _A_ and _B_'s <del>[[EvaluationError]]</del><ins>[[EvaluationResult]]</ins> fields, while _C_ is left as `"evaluated"` with <del>no [[EvaluationError]]</del><ins>its [[EvaluationResult]] set to *undefined*.</p>
   </emu-clause>
 
   <emu-clause id="sec-toplevelmoduleevaluationjob" aoid="TopLevelModuleEvaluationJob">

--- a/spec.html
+++ b/spec.html
@@ -473,6 +473,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
             1. Assert: _requiredModule_ is a Cyclic Module Record.
             1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
           1. <ins>Otherwise, set _requiredModule_ to GetCycleRoot(_requiredModule_).</ins>
+          1. <ins>If _requiredModule_.[[EvaluationError]] is not *undefined*, return _module_.[[EvaluationError]].</ins>
           1. <ins>If _requiredModule_.[[Status]] is `"evaluating-async"`, then</ins>
             1. <ins>Set _module_.[[PendingAsyncDependencies]] to _module_.[[PendingAsyncDependencies]] + 1.</ins>
             1. <ins>Append _module_ to _requiredModule.[[AsyncParentModules]]_.</ins>

--- a/spec.html
+++ b/spec.html
@@ -467,41 +467,37 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. Set _module_.[[Status]] to `"evaluating"`.
         1. Set _module_.[[DFSIndex]] to _index_.
         1. Set _module_.[[DFSAncestorIndex]] to _index_.
+        1. <ins>If _module_.[[Async]] is *true*, then</ins>
+          1. <ins>Set _module_.[[PendingAsyncDependencies]] to 0.</ins>
+          1. <ins>Set _module_.[[AsyncParentModules]] to a new empty List.</ins>
+          1. <ins>Let _capability_ be ! NewPromiseCapability(%Promise%).</ins>
+          1. <ins>Set _module_.[[EvaluationCapability]] to _capability_.</ins>
         1. Set _index_ to _index_ + 1.
         1. Append _module_ to _stack_.
-        1. <ins>Let _pendingAsyncDependencies_ be 0.</ins>
         1. For each String _required_ that is an element of _module_.[[RequestedModules]], do
           1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
           1. NOTE: Instantiate must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
-          1. <ins>If _requiredModule_.[[Async]] is *true*, then</ins>
-            1. <ins>If _requiredModule_.[[Status]] is `"instantiated"`, then</ins>
-              1. <ins>Set _pendingAsyncDependencies_ to _pendingAsyncDependencies_ + 1.</ins>
-              1. <ins>Append _module_ to _requiredModule.[[AsyncParentModules]]_.</ins>
-            1. <ins>Otherwise if _requiredModule_.[[Status]] is `"evaluating-async"`</ins>
-              1. <ins>Assert: This module execution was initiated by another top-level execution job.</ins>
-              1. <ins>Set _pendingAsyncDependencies_ to _pendingAsyncDependencies_ + 1.</ins>
-              1. <ins>Let _stepsFulfilled_ be the steps of _AsyncExecutionFulfilled_.</ins>
-              1. <ins>Let _onFulfilled_ be CreateBuiltinFunction(_stepsFulfilled_, &laquo; [[Module]] &raquo;).</ins>
-              1. <ins>Set _onFulfilled_.[[Module]] to _requiredModule_.</ins>
-              1. <ins>Let _stepsRejected_ be the steps of _AsyncExecutionRejected_.</ins>
-              1. <ins>Let _onRejected_ be CreateBuiltinFunction(_stepsRejected_, &laquo; [[Module]] &raquo;).</ins>
-              1. <ins>Set _onRejected_.[[Module]] to _requiredModule_.</ins>
-              1. <ins>Perform ! PerformPromiseThen(_requiredModule_.[[EvaluationCapability]].[[Promise]], _onFulfilled_, _onRejected_).</ins>
-          1. Set _index_ to ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_).
+          1. <del>Set _index_ to</del><ins>Let _newIndex_ be </ins> ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_).
+          1. <ins>If _requiredModule_.[[Async]] is *true* and _newIndex_ is greater than _index_, then</ins>
+            1. <ins>Set _module_.[[PendingAsyncDependencies]]_ to _module_.[[PendingAsyncDependencies]]_ + 1.</ins>
+            1. <ins>Append _module_ to _requiredModule.[[AsyncParentModules]]_.</ins>
+          1. <ins>Otherwise, if _requiredModule_.[[Status]] is `"evaluating-async"`</ins>
+            1. <ins>Assert: This module execution was initiated by another top-level execution job.</ins>
+            1. <ins>Set _module_.[[PendingAsyncDependencies]]_ to _module_.[[PendingAsyncDependencies]]_ + 1.</ins>
+            1. <ins>Let _stepsFulfilled_ be the steps of _AsyncExecutionFulfilled_.</ins>
+            1. <ins>Let _onFulfilled_ be CreateBuiltinFunction(_stepsFulfilled_, &laquo; [[Module]] &raquo;).</ins>
+            1. <ins>Set _onFulfilled_.[[Module]] to _requiredModule_.</ins>
+            1. <ins>Let _stepsRejected_ be the steps of _AsyncExecutionRejected_.</ins>
+            1. <ins>Let _onRejected_ be CreateBuiltinFunction(_stepsRejected_, &laquo; [[Module]] &raquo;).</ins>
+            1. <ins>Set _onRejected_.[[Module]] to _requiredModule_.</ins>
+            1. <ins>Perform ! PerformPromiseThen(_requiredModule_.[[EvaluationCapability]].[[Promise]], _onFulfilled_, _onRejected_).</ins></ins>
           1. Assert: _requiredModule_.[[Status]] is either `"evaluating"` <ins>`"evaluating-async"`</ins> or `"evaluated"`.
           1. Assert: _requiredModule_.[[Status]] is `"evaluating"` if and only if _requiredModule_ is in _stack_.
           1. If _requiredModule_.[[Status]] is `"evaluating"`, then
             1. Assert: _requiredModule_ is a Cyclic Module Record.
             1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
-        1. <ins>If _module_.[[Async]] is *false*, then</ins>
+        1. <ins>If _module_.[[Async]] is *false* or the length of _module_.[[PendingAsyncDependencies]] is 0, then</ins>
           1. Perform ? _module_.ExecuteModule()
-        1. <ins>Otherwise,</ins>
-          1. <ins>Set _module_.[[AsyncParentModules]] to a new empty List.</ins>
-          1. <ins>Set _module_.[[PendingAsyncDependencies]] to the length of _pendingAsyncDependencies_.</ins>
-          1. <ins>Let _capability_ be ! NewPromiseCapability(%Promise%).</ins>
-          1. <ins>Set _module_.[[EvaluationCapability]] to _capability_.</ins>
-          1. <ins>If the length of _pendingAsyncDependencies_ is 0, then</ins>
-            1. <ins>Perform ! _module_.ExecuteModule().</ins>
         1. Assert: _module_ occurs exactly once in _stack_.
         1. Assert: _module_.[[DFSAncestorIndex]] is less than or equal to _module_.[[DFSIndex]].
         1. If _module_.[[DFSAncestorIndex]] equals _module_.[[DFSIndex]], then

--- a/spec.html
+++ b/spec.html
@@ -478,6 +478,11 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
           1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
           1. NOTE: Instantiate must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
           1. <del>Set _index_ to</del><ins>Let _newIndex_ be </ins> ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_).
+          1. Assert: _requiredModule_.[[Status]] is either `"evaluating"` <ins>`"evaluating-async"`</ins> or `"evaluated"`.
+          1. Assert: _requiredModule_.[[Status]] is `"evaluating"` if and only if _requiredModule_ is in _stack_.
+          1. If _requiredModule_.[[Status]] is `"evaluating"`, then
+            1. Assert: _requiredModule_ is a Cyclic Module Record.
+            1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
           1. <ins>If _requiredModule_.[[Async]] is *true* and _newIndex_ is greater than _index_, then</ins>
             1. <ins>Set _module_.[[PendingAsyncDependencies]]_ to _module_.[[PendingAsyncDependencies]]_ + 1.</ins>
             1. <ins>Append _module_ to _requiredModule.[[AsyncParentModules]]_.</ins>
@@ -491,11 +496,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
             1. <ins>Let _onRejected_ be CreateBuiltinFunction(_stepsRejected_, &laquo; [[Module]] &raquo;).</ins>
             1. <ins>Set _onRejected_.[[Module]] to _requiredModule_.</ins>
             1. <ins>Perform ! PerformPromiseThen(_requiredModule_.[[EvaluationCapability]].[[Promise]], _onFulfilled_, _onRejected_).</ins></ins>
-          1. Assert: _requiredModule_.[[Status]] is either `"evaluating"` <ins>`"evaluating-async"`</ins> or `"evaluated"`.
-          1. Assert: _requiredModule_.[[Status]] is `"evaluating"` if and only if _requiredModule_ is in _stack_.
-          1. If _requiredModule_.[[Status]] is `"evaluating"`, then
-            1. Assert: _requiredModule_ is a Cyclic Module Record.
-            1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
+          1. <ins>Set _index_ to _newIndex_.</ins>
         1. <ins>If _module_.[[Async]] is *false* or the length of _module_.[[PendingAsyncDependencies]] is 0, then</ins>
           1. Perform ? _module_.ExecuteModule()
         1. Assert: _module_ occurs exactly once in _stack_.

--- a/spec.html
+++ b/spec.html
@@ -294,7 +294,18 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         </tr>
         <tr>
           <td>
-            <ins>[[AsyncExecParent]]</ins>
+            <ins>[[AsyncInitiator]]</ins>
+          </td>
+          <td>
+            <ins>Cyclic Module Record | *undefined*</ins>
+          </td>
+          <td>
+            <ins>If [[Async]] is true and execution has started, this tracks the top-level async job of this module.</ins>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <ins>[[AsyncParentModules]]</ins>
           </td>
           <td>
             <ins>List of Cyclic Module Record | *undefined*</ins>
@@ -434,7 +445,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
       1. Let _module_ be this Source Text Module Record.
       1. Assert: _module_.[[Status]] is `"instantiated"`, <ins>`"evaluating-async"`</ins> or `"evaluated"`.
       1. Let _stack_ be a new empty List.
-      1. Let _result_ be InnerModuleEvaluation(_module_, <ins>*undefined*</ins>_stack_, 0).
+      1. Let _result_ be InnerModuleEvaluation(_module_, _stack_, 0).
       1. If _result_ is an abrupt completion, then
         1. For each module _m_ in _stack_, do
           1. Assert: _m_.[[Status]] is `"evaluating"`.
@@ -449,7 +460,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
     </emu-alg>
 
     <emu-clause id="sec-innermoduleevaluation" aoid="InnerModuleEvaluation">
-      <h1>InnerModuleEvaluation( _module_, <ins>_parent_, </ins>_stack_, _index_ )</h1>
+      <h1>InnerModuleEvaluation( _module_, _stack_, _index_ )</h1>
 
       <p>The InnerModuleEvaluation abstract operation is used by Evaluate to perform the actual evaluation process for the Cyclic Module Record _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSIndex]] and [[DFSAncestoreIndex]] fields, are used the same way as in InnerModuleInstantiation.</p>
 
@@ -459,43 +470,45 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. If _module_ is not a Source Text Module Record, then
           1. Perform _module_.Evaluate().
           1. Return _index_.
-        1. If _module_.[[Status]] is `"evaluated"`, then
+        1. If _module_.[[Status]] is `"evaluated"` <ins> or `"evaluating-async"`</ins>, then
           1. If _module_.[[EvaluationError]] is *undefined*, return _index_.
           1. Otherwise return _module_.[[EvaluationError]].
-        1. <ins>If _module_.[[Status]] is `"evaluating-async"`, then</ins>
-          1. <ins>Set _parent_.[[PendingAsyncDependencies]]_ to _parent_.[[PendingAsyncDependencies]]_ + 1.</ins>
-          1. <ins>Let _stepsFulfilled_ be the steps of _AsyncExecutionFulfilled_.</ins>
-          1. <ins>Let _onFulfilled_ be CreateBuiltinFunction(_stepsFulfilled_, &laquo; [[Module]] &raquo;).</ins>
-          1. <ins>Set _onFulfilled_.[[Module]] to _requiredModule_.</ins>
-          1. <ins>Let _stepsRejected_ be the steps of _AsyncExecutionRejected_.</ins>
-          1. <ins>Let _onRejected_ be CreateBuiltinFunction(_stepsRejected_, &laquo; [[Module]] &raquo;).</ins>
-          1. <ins>Set _onRejected_.[[Module]] to _requiredModule_.</ins>
-          1. <ins>Set _parent_.[[PendingAsyncDependencies]]_ to _parent_.[[PendingAsyncDependencies]]_ + 1.</ins>
-          1. <ins>Perform ! PerformPromiseThen(_module_.[[EvaluationCapability]].[[Promise]], _onFulfilled_, _onRejected_).</ins></ins>
-          1. <ins>Return *undefined*.</ins>
         1. If _module_.[[Status]] is `"evaluating"`, return _index_.
         1. Assert: _module_.[[Status]] is `"instantiated"`.
         1. Set _module_.[[Status]] to `"evaluating"`.
         1. Set _module_.[[DFSIndex]] to _index_.
         1. Set _module_.[[DFSAncestorIndex]] to _index_.
-        1. <ins>If _module_.[[Async]] is *true*, then</ins>
-          1. <ins>Set _module_.[[AsyncExecParent]] to _parent_.</ins>
-          1. <ins>Set _parent_.[[PendingAsyncDependencies]]_ to _parent_.[[PendingAsyncDependencies]]_ + 1.</ins>
-          1. <ins>Set _module_.[[PendingAsyncDependencies]] to 0.</ins>
-          1. <ins>Set _module_.[[AsyncExecParent]] to a new empty List.</ins>
-          1. <ins>Let _capability_ be ! NewPromiseCapability(%Promise%).</ins>
-          1. <ins>Set _module_.[[EvaluationCapability]] to _capability_.</ins>
         1. Set _index_ to _index_ + 1.
         1. Append _module_ to _stack_.
+        1. <ins>If _module_.[[Async]] is *true*, then</ins>
+          1. <ins>Set _module_.[[PendingAsyncDependencies]] to 0.</ins>
+          1. <ins>Set _module_.[[AsyncParentModules]] to a new empty List.</ins>
+          1. <ins>Let _capability_ be ! NewPromiseCapability(%Promise%).</ins>
+          1. <ins>Set _module_.[[EvaluationCapability]] to _capability_.</ins>
+          1. <ins>Set _module_.[[AsyncInitiator]] to the first module of _stack_.</ins>
         1. For each String _required_ that is an element of _module_.[[RequestedModules]], do
           1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
           1. NOTE: Instantiate must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
-          1. Set _index_ to ? InnerModuleEvaluation(_requiredModule_, <ins>_module_, </ins>_stack_, _index_).
+          1. Set _index_ to ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_).
           1. Assert: _requiredModule_.[[Status]] is either `"evaluating"` <ins>`"evaluating-async"`</ins> or `"evaluated"`.
           1. Assert: _requiredModule_.[[Status]] is `"evaluating"` if and only if _requiredModule_ is in _stack_.
           1. If _requiredModule_.[[Status]] is `"evaluating"`, then
             1. Assert: _requiredModule_ is a Cyclic Module Record.
             1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
+          1. <ins>If _requiredModule_.[[Status]] is `"evaluating-async"`, then</ins>
+            1. <ins>If _requiredModule_.[[AsyncInitiator]] is the first module of _stack_, then</ins>
+              1. <ins>Set _module_.[[PendingAsyncDependencies]]_ to _module_.[[PendingAsyncDependencies]]_ + 1.</ins>
+              1. <ins>Append _module_ to _requiredModule.[[AsyncParentModules]]_.</ins>
+            1. <ins>Otherwise,</ins>
+              1. <ins>Assert: This module execution was initiated by another top-level execution job.</ins>
+              1. <ins>Set _module_.[[PendingAsyncDependencies]]_ to _module_.[[PendingAsyncDependencies]]_ + 1.</ins>
+              1. <ins>Let _stepsFulfilled_ be the steps of _AsyncExecutionFulfilled_.</ins>
+              1. <ins>Let _onFulfilled_ be CreateBuiltinFunction(_stepsFulfilled_, &laquo; [[Module]] &raquo;).</ins>
+              1. <ins>Set _onFulfilled_.[[Module]] to _requiredModule_.</ins>
+              1. <ins>Let _stepsRejected_ be the steps of _AsyncExecutionRejected_.</ins>
+              1. <ins>Let _onRejected_ be CreateBuiltinFunction(_stepsRejected_, &laquo; [[Module]] &raquo;).</ins>
+              1. <ins>Set _onRejected_.[[Module]] to _requiredModule_.</ins>
+              1. <ins>Perform ! PerformPromiseThen(_requiredModule_.[[EvaluationCapability]].[[Promise]], _onFulfilled_, _onRejected_).</ins>
         1. <ins>If _module_.[[Async]] is *false* or the length of _module_.[[PendingAsyncDependencies]] is 0, then</ins>
           1. Perform ? _module_.ExecuteModule()
         1. Assert: _module_ occurs exactly once in _stack_.
@@ -524,12 +537,11 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. Let _module_ be _f_.[[Module]].
         1. Assert: _module_.[[Status]] is `"evaluating-async"`.
         1. Set _module_.[[Status]] to `"evaluated"`.
-        1. Let _execParent_ be _module_.[[AsyncParent]].
-        1. If _execParent_ is not *undefined*, then
-          1. Decrement _execParent_.[[PendingAsyncDependencies]] by 1.
-          1. If _execParent_.[[PendingAsyncDependencies]] is 0 and _execParent_.[[EvaluationError]] is *undefined*, then
-            1. Assert _execParent_.[[Status]] is `"evaluating-async"`.
-            1. Perform ! _execParent_.ExecuteModule().
+        1. For each Module _m_ of _module_.[[AsyncParentModules]], do
+          1. Decrement _m_.[[PendingAsyncDependencies]] by 1.
+          1. If _m_.[[PendingAsyncDependencies]] is 0 and _m_.[[EvaluationError]] is *undefined*, then
+            1. Assert _m_.[[Status]] is `"evaluating-async"`.
+            1. Perform ! _module_.ExecuteModule().
         1. If _module_.[[DFSAncestorIndex]] equals _module_.[[DFSIndex]], then
           1. Perform ! Call(_module_.[[EvaluationCapability]].[[Resolve]], *undefined*, &laquo;*undefined*&raquo;).
         1. Return *undefined*.
@@ -548,12 +560,11 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. Assert: _module_.[[EvaluationError]] is *undefined*.
         1. Set _module_.[[Status]] to `"evaluated"`.
         1. Set _module_.[[EvaluationError]] to ThrowCompletion(_error_).
-        1. Let _execParent_ be _module_.[[AsyncParent]].
-        1. If _execParent_ is not *undefined*, then
-          1. If _execParent_.[[Status]] is `"evaluating-async"`, then
+        1. For each Module _m_ of _module_.[[AsyncParentModules]], do
+          1. If _m_.[[Status]] is `"evaluating-async"`, then
             1. Let _stepsRejected_ be the steps of _AsyncExecutionRejected_.
             1. Let _parentRejected_ be CreateBuiltinFunction(_stepsRejected_, &laquo; [[Module]] &raquo;).
-            1. Set _parentRejected_.[[Module]] to _execParent_.
+            1. Set _parentRejected_.[[Module]] to _m_.
             1. Perform ! Call(_parentRejected_, *undefined*, &laquo; _error_ &raquo;).
         1. Perform ! Call(_module_.[[EvaluationCapability]].[[Reject]], *undefined*, &laquo;_error_&raquo;).
         1. Return *undefined*.
@@ -595,7 +606,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. Else,
           1. Append _ee_ to _indirectExportEntries_.
       1. <ins>Let _async_ be _body_ Contains |AwaitExpression|.</ins>
-      1. Return Source Text Module Record { [[Realm]]: _realm_, [[Environment]]: *undefined*, [[Namespace]]: *undefined*, <ins>[[Async]]: _async_, [[EvaluationCapability]]: *undefined*, [[AsyncExecParent]]: *undefined*, [[PendingAsyncDependencies]]: *undefined*, </ins>[[Status]]: `"uninstantiated"`, [[EvaluationError]]: *undefined*, [[HostDefined]]: _hostDefined_, [[ECMAScriptCode]]: _body_, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[DFSIndex]]: *undefined*, [[DFSAncestorIndex]]: *undefined*, <ins>[[ModuleAsync]]: _async_</ins> }.
+      1. Return Source Text Module Record { [[Realm]]: _realm_, [[Environment]]: *undefined*, [[Namespace]]: *undefined*, <ins>[[Async]]: _async_, [[EvaluationCapability]]: *undefined*, [[AsyncParentModules]]: *undefined*, [[PendingAsyncDependencies]]: *undefined*, </ins>[[Status]]: `"uninstantiated"`, [[EvaluationError]]: *undefined*, [[HostDefined]]: _hostDefined_, [[ECMAScriptCode]]: _body_, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[DFSIndex]]: *undefined*, [[DFSAncestorIndex]]: *undefined*, <ins>[[ModuleAsync]]: _async_</ins> }.
     </emu-alg>
     <emu-note>
       <p>An implementation may parse module source text and analyse it for Early Error conditions prior to the evaluation of ParseModule for that module source text. However, the reporting of any errors must be deferred until the point where this specification actually performs ParseModule upon that source text.</p>

--- a/spec.html
+++ b/spec.html
@@ -128,28 +128,6 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
           Field reserved for use by host environments that need to associate additional information with a module.
         </td>
       </tr>
-      <tr>
-        <td>
-          <ins>[[Async]]</ins>
-        </td>
-        <td>
-          <ins>*true* or *false*</ins>
-        </td>
-        <td>
-          <ins>Indicates whether this module is asynchronous. Abstract Module Record subclasses must not modify this field after the Instantiation phase.</ins>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <ins>[[EvaluationCapability]]</ins>
-        </td>
-        <td>
-          <ins>*undefined* | PromiseCapability</ins>
-        </td>
-        <td>
-          <ins>If [[Async]] is true, and evaluation of this module has begun, this field stores a PromiseCapability that resolves or rejects when evaluation of the module is complete.</ins>
-        </td>
-      </tr>
       </tbody>
     </table>
   </emu-table>
@@ -199,7 +177,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
           Evaluate()
         </td>
         <td>
-          <p>If this module has already been evaluated successfully, return *undefined*; if it has already been evaluated unsuccessfully, throw the exception that was produced. Otherwise, Transitively evaluate all module dependencies of this module and then evaluate this module.</p>
+          <p><ins>Returns a promise for the evaluation of this module and its dependencies, resolving on successful evaluation or if it has already been evaluated, and rejecting for an evaluation error or</ins><del>If this module has already been evaluated successfully, return *undefined*; </del>if it has already been evaluated unsuccessfully<del>, throw the exception that was produced. Otherwise, Transitively evaluate all module dependencies of this module and then evaluate this module.</del></p>
           <p>Instantiate must have completed successfully prior to invoking this method.</p>
         </td>
       </tr>
@@ -233,7 +211,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
             String
           </td>
           <td>
-            Initially `"uninstantiated"`. Transitions to `"instantiating"`, `"instantiated"`, `"evaluating"`, `"evaluated"` (in that order) as the module progresses throughout its lifecycle.
+            Initially `"uninstantiated"`. Transitions to `"instantiating"`, `"instantiated"`, `"evaluating"`, <ins>`"evaluating-async`" (for async modules and parents of async modules)</ins>, `"evaluated"` (in that order) as the module progresses throughout its lifecycle.
           </td>
         </tr>
         <tr>
@@ -244,7 +222,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
             An abrupt completion | *undefined*
           </td>
           <td>
-            A completion of type ~throw~ representing the exception that occurred during evaluation.  *undefined* if no exception occurred, <ins>if the module is [[Async]],</ins> or if [[Status]] is not `"evaluated"`.
+            A completion of type ~throw~ representing the exception that occurred during evaluation. *undefined* if no exception occurred, or if [[Status]] is not `"evaluated"`.
           </td>
         </tr>
         <tr>
@@ -283,24 +261,24 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         </tr>
         <tr>
           <td>
-            <ins>[[ModuleAsync]]</ins>
+            <ins>[[Async]]</ins>
           </td>
           <td>
             <ins>*true* or *false*</ins>
           </td>
           <td>
-            <ins>Whether this module is individually asynchronous. A module may have [[Async]] *true* and [[ModuleAsync]] *false* if dependencies are asynchronous, but this module is not. This field must not change after the module is parsed.</ins>
+            <ins>Indicates whether this module contains top-level await syntax.</ins>
           </td>
         </tr>
         <tr>
           <td>
-            <ins>[[AsyncInitiator]]</ins>
+            <ins>[[TopLevelCapability]]</ins>
           </td>
           <td>
-            <ins>Cyclic Module Record | *undefined*</ins>
+            <ins>Promise Capability | *undefined*</ins>
           </td>
           <td>
-            <ins>If [[Async]] is true and execution has started, this tracks the top-level async job of this module.</ins>
+            <ins>If this module corresponds to a top-level evaluation job, this field contains the promise capability for that entire evaluation.</ins>
           </td>
         </tr>
         <tr>
@@ -311,7 +289,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
             <ins>List of Cyclic Module Record | *undefined*</ins>
           </td>
           <td>
-            <ins>If [[Async]] is true and execution has started, this tracks the parent importers of this module for the top-level execution job.</ins>
+            <ins>If this module or a dependency has [[Async]] *true*, and execution is in progress, this tracks the parent importers of this module for the top-level execution job.</ins>
           </td>
         </tr>
         <tr>
@@ -322,7 +300,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
             <ins>Integer | *undefined*</ins>
           </td>
           <td>
-            <ins>If [[Async]] is true and execution has started, this tracks the number of async dependency modules remaining to execute for this module.</ins>
+            <ins>This tracks the number of async dependency modules remaining to execute for this module if it has any asynchronous dependencies.</ins>
           </td>
         </tr>
       </tbody>
@@ -353,7 +331,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
             ExecuteModule( <ins>[ _promiseCapability_ ]</ins> )
           </td>
           <td>
-            Initialize the execution context of the module and evaluate the module's code within it. <ins>If this module has *true* in [[ModuleAsync]], then a Promise Capability is passed as an argument, and the method is expected to resolve or reject the given capability. In this case, the method must not throw an exception, but instead reject the Promise Capability if necessary.</ins>
+            Initialize the execution context of the module and evaluate the module's code within it. <ins>If this module has *true* in [[Async]], then a Promise Capability is passed as an argument, and the method is expected to resolve or reject the given capability. In this case, the method must not throw an exception, but instead reject the Promise Capability if necessary.</ins>
           </td>
         </tr>
         </tbody>
@@ -414,8 +392,6 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
           1. If _requiredModule_.[[Status]] is `"instantiating"`, then
             1. Assert: _requiredModule_ is a Cyclic Module Record.
             1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
-          1. <ins>If _requiredModule_.[[Async]] is *true*, then</ins>
-            1. <ins>Set _module_.[[Async]] to *true*.</ins>
         1. Perform ? _module_.InitializeEnvironment().
         1. Assert: _module_ occurs exactly once in _stack_.
         1. Assert: _module_.[[DFSAncestorIndex]] is less than or equal to _module_.[[DFSIndex]].
@@ -443,8 +419,13 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
 
     <emu-alg>
       1. Let _module_ be this Source Text Module Record.
-      1. Assert: _module_.[[Status]] is `"instantiated"`, <ins>`"evaluating-async"`</ins> or `"evaluated"`.
+      1. Assert: _module_.[[Status]] is `"instantiated"`<ins>, `"evaluating-async"`</ins> or `"evaluated"`.
+      1. <ins>If _module_.[[Status]] is `"evaluated"` or `"evaluating-async"`, set _module_ to GetAsyncCycleRoot(_module_).</ins>
+      1. <ins>If _module_.[[TopLevelCapability]] is not *undefined*, then</ins>
+        1. <ins>Return _module_.[[TopLevelCapability]].</ins>
       1. Let _stack_ be a new empty List.
+      1. <ins>Let _capability_ be ! NewPromiseCapability(%Promise%).</ins>
+      1. <ins>Set _module_.[[TopLevelCapability]] to _capability_.</ins>
       1. Let _result_ be InnerModuleEvaluation(_module_, _stack_, 0).
       1. If _result_ is an abrupt completion, then
         1. For each module _m_ in _stack_, do
@@ -452,11 +433,12 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
           1. Set _m_.[[Status]] to `"evaluated"`.
           1. Set _m_.[[EvaluationError]] to _result_.
         1. Assert: _module_.[[Status]] is `"evaluated"` and _module_.[[EvaluationError]] is _result_.
-        1. Return _result_.
-      1. Assert: _module_.[[Status]] is `"evaluated"`<ins> or `"evaluating-async"`</ins> and _module_.[[EvaluationError]] is *undefined*.
+        1. <del>Return _result_.</del>
+        1. <ins>Perform ! Call(_module_.[[TopLevelCapability]].[[Reject]], *undefined*, &laquo;_result_.[[Value]]&raquo;).</ins>
+        1. <ins>Return _capability_.[[Promise]].</ins>
+      1. Assert: _module_.[[Status]] is `"evaluated"`<ins> or `"evaluating-async"`</ins><del> and _module_.[[EvaluationError]] is *undefined*</del>.
       1. Assert: _stack_ is empty.
-      1. <ins>If _module_.[[Async]] is *true*, return _module_.[[EvaluationPromise]].</ins>
-      1. <ins>Otherwise</ins>, return *undefined*.
+      1. Return <del>*undefined*</del><ins>_capability_.[[Promise]]</ins>.
     </emu-alg>
 
     <emu-clause id="sec-innermoduleevaluation" aoid="InnerModuleEvaluation">
@@ -478,38 +460,25 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. Set _module_.[[Status]] to `"evaluating"`.
         1. Set _module_.[[DFSIndex]] to _index_.
         1. Set _module_.[[DFSAncestorIndex]] to _index_.
+        1. <ins>Set _module_.[[PendingAsyncDependencies]] to 0.</ins>
         1. Set _index_ to _index_ + 1.
         1. Append _module_ to _stack_.
-        1. <ins>If _module_.[[Async]] is *true*, then</ins>
-          1. <ins>Set _module_.[[PendingAsyncDependencies]] to 0.</ins>
-          1. <ins>Set _module_.[[AsyncParentModules]] to a new empty List.</ins>
-          1. <ins>Let _capability_ be ! NewPromiseCapability(%Promise%).</ins>
-          1. <ins>Set _module_.[[EvaluationCapability]] to _capability_.</ins>
-          1. <ins>Set _module_.[[AsyncInitiator]] to the first module of _stack_.</ins>
         1. For each String _required_ that is an element of _module_.[[RequestedModules]], do
           1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
           1. NOTE: Instantiate must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
           1. Set _index_ to ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_).
-          1. Assert: _requiredModule_.[[Status]] is either `"evaluating"` <ins>`"evaluating-async"`</ins> or `"evaluated"`.
+          1. Assert: _requiredModule_.[[Status]] is either `"evaluating"`<ins>, `"evaluating-async"`</ins> or `"evaluated"`.
           1. Assert: _requiredModule_.[[Status]] is `"evaluating"` if and only if _requiredModule_ is in _stack_.
           1. If _requiredModule_.[[Status]] is `"evaluating"`, then
             1. Assert: _requiredModule_ is a Cyclic Module Record.
             1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
+          1. <ins>Otherwise, set _requiredModule_ to GetAsyncCycleRoot(_requiredModule_).</ins>
           1. <ins>If _requiredModule_.[[Status]] is `"evaluating-async"`, then</ins>
-            1. <ins>If _requiredModule_.[[AsyncInitiator]] is the first module of _stack_, then</ins>
-              1. <ins>Set _module_.[[PendingAsyncDependencies]]_ to _module_.[[PendingAsyncDependencies]]_ + 1.</ins>
-              1. <ins>Append _module_ to _requiredModule.[[AsyncParentModules]]_.</ins>
-            1. <ins>Otherwise,</ins>
-              1. <ins>Assert: This module execution was initiated by another top-level execution job.</ins>
-              1. <ins>Set _module_.[[PendingAsyncDependencies]]_ to _module_.[[PendingAsyncDependencies]]_ + 1.</ins>
-              1. <ins>Let _stepsFulfilled_ be the steps of _AsyncExecutionFulfilled_.</ins>
-              1. <ins>Let _onFulfilled_ be CreateBuiltinFunction(_stepsFulfilled_, &laquo; [[Module]] &raquo;).</ins>
-              1. <ins>Set _onFulfilled_.[[Module]] to _requiredModule_.</ins>
-              1. <ins>Let _stepsRejected_ be the steps of _AsyncExecutionRejected_.</ins>
-              1. <ins>Let _onRejected_ be CreateBuiltinFunction(_stepsRejected_, &laquo; [[Module]] &raquo;).</ins>
-              1. <ins>Set _onRejected_.[[Module]] to _requiredModule_.</ins>
-              1. <ins>Perform ! PerformPromiseThen(_requiredModule_.[[EvaluationCapability]].[[Promise]], _onFulfilled_, _onRejected_).</ins>
-        1. <ins>If _module_.[[Async]] is *false* or the length of _module_.[[PendingAsyncDependencies]] is 0, then</ins>
+            1. <ins>Set _module_.[[PendingAsyncDependencies]] to _module_.[[PendingAsyncDependencies]] + 1.</ins>
+            1. <ins>If _requiredModule_.[[AsyncParentModules]]_ is *undefined*, then</ins>
+              1. <ins>Set _requiredModule_.[[AsyncParentModules]] to a new empty List.</ins>
+            1. <ins>Append _module_ to _requiredModule.[[AsyncParentModules]]_.</ins>
+        1. <ins>If _module_.[[PendingAsyncDependencies]] is 0, then</ins>
           1. Perform ? _module_.ExecuteModule()
         1. Assert: _module_ occurs exactly once in _stack_.
         1. Assert: _module_.[[DFSAncestorIndex]] is less than or equal to _module_.[[DFSIndex]].
@@ -518,55 +487,69 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
           1. Repeat, while _done_ is *false*,
             1. Let _requiredModule_ be the last element in _stack_.
             1. Remove the last element of _stack_.
-            1. <ins>If _module_.[[Async]] is *true*, set _requiredModule_.[[Status]] to `"evaluating-async"`.</ins>
+            1. <ins>If _module_.[[Async]] is *true* or _module_.[[PendingAsyncDependencies]] is not 0, then</ins>
+              1. <ins>Set _requiredModule_.[[Status]] to `"evaluating-async"`.</ins>
             1. <ins>Otherwise, </ins>set _requiredModule_.[[Status]] to `"evaluated"`.
             1. If _requiredModule_ and _module_ are the same Module Record, set _done_ to *true*.
-            1. <ins>Otherwise, if _module_.[[Async]] is *true*,</ins>
-              1. <ins>Set _requiredModule_.[[EvaluationCapability]] to _module_.[[EvaluationCapability]].</ins>
+            1. Otherwise, if _requiredModule_.[[TopLevelCapability]] is not *undefined*
         1. Return _index_.
       </emu-alg>
       <emu-note>
-        <p>A module is `"evaluating"` while it is being traversed by InnerModuleEvaluation. A module is `"evaluated"` on execution completion, and `"evaluating-async"` during execution if it is an asynchronous module.</p>
+        <p><ins>A module is `"evaluating"` while it is being traversed by InnerModuleEvaluation. A module is `"evaluated"` on execution completion, and `"evaluating-async"` during execution if it is an asynchronous module.</ins></p>
+      </emu-note>
+      <emu-note>
+        <p><ins>Any modules depending on a module of an async cycle when that cycle is not `"evaluating"` will instead depend on the execution of the root of the cycle via GetAsyncCycleRoot. This ensures that the cycle state can be treated as a single strongly connected component through its root module state.</ins></p>
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-executionfulfilled" aoid="AsyncExecutionFulfilled">
-      <h1><ins>AsyncExecutionFulfilled ()</ins></h1>
+    <emu-clause id="sec-getasynccycleroot" aoid="GetAsyncCycleRoot">
+      <h1><ins>GetAsyncCycleRoot ( _module_ )</ins></h1>
       <emu-alg>
-        1. Let _f_ be the active function object.
-        1. Let _module_ be _f_.[[Module]].
+        1. Repeat, while _module_.[[DFSIndex]] is greater than _module_.[[DFSAncestorIndex]],
+          1. Assert: _module_.[[AsyncParentModules]] is a non-empty List.
+          1. Let _nextCycleModule_ be the first element of _module_.[[AsyncParentModules]].
+          1. Assert: _nextCycleModule_.[[DFSAncestorIndex]] is equal to _module_.[[DFSAncestorIndex]].
+          1. Set _module_ to _nextCycleModule_.
+        1. Assert: _module_.[[DFSIndex]] is equal to _module_.[[DFSAncestorIndex]].
+        1. Return _module_.
+      </emu-alg>
+    </emu-clause>
+
+    <emu-clause id="sec-executionfulfilled" aoid="AsyncExecutionFulfilled">
+      <h1><ins>AsyncExecutionFulfilled ( _module_ )</ins></h1>
+      <emu-alg>
         1. Assert: _module_.[[Status]] is `"evaluating-async"`.
+        1. Assert: _module_.[[EvaluationError]] is *undefined*.
         1. Set _module_.[[Status]] to `"evaluated"`.
         1. For each Module _m_ of _module_.[[AsyncParentModules]], do
+          1. If _module_.[[DFSIndex]] is not equal to _module_.[[DFSAncestorIndex]], then
+            1. Assert: _m_.[[DFSAncestorIndex]] is equal to _module_.[[DFSAncestorIndex]].
           1. Decrement _m_.[[PendingAsyncDependencies]] by 1.
           1. If _m_.[[PendingAsyncDependencies]] is 0 and _m_.[[EvaluationError]] is *undefined*, then
             1. Assert _m_.[[Status]] is `"evaluating-async"`.
             1. Perform ! _module_.ExecuteModule().
-        1. If _module_.[[DFSAncestorIndex]] equals _module_.[[DFSIndex]], then
-          1. Perform ! Call(_module_.[[EvaluationCapability]].[[Resolve]], *undefined*, &laquo;*undefined*&raquo;).
+        1. If _module_.[[TopLevelCapability]] is not *undefined*, then
+          1. Assert: _module_.[[DFSIndex]] is equal to _module_.[[DFSAncestorIndex]].
+          1. Perform ! Call(_module_.[[TopLevelCapability]].[[Resolve]], *undefined*, &laquo;*undefined*&raquo;).
         1. Return *undefined*.
       </emu-alg>
-      <emu-note>
-        <p>When propagating ExecuteModule calls up the parent stack through multiple AsyncExecutionFulfilled handlers, the execution context should not be changed apart from the direct execution of the modules being executed in the stack.</p>
-      </emu-note>
     </emu-clause>
 
     <emu-clause id="sec-executionrejected" aoid="AsyncExecutionRejected">
-      <h1><ins>AsyncExecutionRejected ( _error_ )</ins></h1>
+      <h1><ins>AsyncExecutionRejected ( _module_, _error_ )</ins></h1>
       <emu-alg>
-        1. Let _f be the active function object.
-        1. Let _module_ be _f_.[[Module]].
         1. Assert: _module_.[[Status]] is `"evaluating-async"`.
         1. Assert: _module_.[[EvaluationError]] is *undefined*.
         1. Set _module_.[[Status]] to `"evaluated"`.
         1. Set _module_.[[EvaluationError]] to ThrowCompletion(_error_).
         1. For each Module _m_ of _module_.[[AsyncParentModules]], do
+          1. If _module_.[[DFSIndex]] is not equal to _module_.[[DFSAncestorIndex]], then
+            1. Assert: _m_.[[DFSAncestorIndex]] is equal to _module_.[[DFSAncestorIndex]].
           1. If _m_.[[Status]] is `"evaluating-async"`, then
-            1. Let _stepsRejected_ be the steps of _AsyncExecutionRejected_.
-            1. Let _parentRejected_ be CreateBuiltinFunction(_stepsRejected_, &laquo; [[Module]] &raquo;).
-            1. Set _parentRejected_.[[Module]] to _m_.
-            1. Perform ! Call(_parentRejected_, *undefined*, &laquo; _error_ &raquo;).
-        1. Perform ! Call(_module_.[[EvaluationCapability]].[[Reject]], *undefined*, &laquo;_error_&raquo;).
+            1. Perform ! AsyncExecutionRejected(_m_, _error_).
+        1. If _module_.[[TopLevelCapability]] is not *undefined*, then
+          1. Assert: _module_.[[DFSIndex]] is equal to _module_.[[DFSAncestorIndex]].
+          1. Perform ! Call(_module_.[[TopLevelCapability]].[[Reject]], *undefined*, &laquo;_error_&raquo;).
         1. Return *undefined*.
       </emu-alg>
     </emu-clause>
@@ -606,7 +589,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. Else,
           1. Append _ee_ to _indirectExportEntries_.
       1. <ins>Let _async_ be _body_ Contains |AwaitExpression|.</ins>
-      1. Return Source Text Module Record { [[Realm]]: _realm_, [[Environment]]: *undefined*, [[Namespace]]: *undefined*, <ins>[[Async]]: _async_, [[EvaluationCapability]]: *undefined*, [[AsyncParentModules]]: *undefined*, [[PendingAsyncDependencies]]: *undefined*, </ins>[[Status]]: `"uninstantiated"`, [[EvaluationError]]: *undefined*, [[HostDefined]]: _hostDefined_, [[ECMAScriptCode]]: _body_, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[DFSIndex]]: *undefined*, [[DFSAncestorIndex]]: *undefined*, <ins>[[ModuleAsync]]: _async_</ins> }.
+      1. Return Source Text Module Record { [[Realm]]: _realm_, [[Environment]]: *undefined*, [[Namespace]]: *undefined*, <ins>[[Async]]: _async_, [[TopLevelCapability]]: *undefined*, [[AsyncParentModules]]: *undefined*, [[PendingAsyncDependencies]]: *undefined*, </ins>[[Status]]: `"uninstantiated"`, [[EvaluationError]]: *undefined*, [[HostDefined]]: _hostDefined_, [[ECMAScriptCode]]: _body_, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[DFSIndex]]: *undefined*, [[DFSAncestorIndex]]: *undefined* }.
     </emu-alg>
     <emu-note>
       <p>An implementation may parse module source text and analyse it for Early Error conditions prior to the evaluation of ParseModule for that module source text. However, the reporting of any errors must be deferred until the point where this specification actually performs ParseModule upon that source text.</p>
@@ -629,7 +612,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. Set the VariableEnvironment of _moduleCxt_ to _module_.[[Environment]].
         1. Set the LexicalEnvironment of _moduleCxt_ to _module_.[[Environment]].
         1. Suspend the currently running execution context.
-        1. <ins>If _module_.[[ModuleAsync]] is *false*, then</ins>
+        1. <ins>If _module_.[[Async]] is *false*, then</ins>
           1. Push _moduleCxt_ on to the execution context stack; _moduleCxt_ is now the running execution context.
           1. Let _result_ be the result of evaluating _module_.[[ECMAScriptCode]].
           1. Suspend _moduleCxt_ and remove it from the execution context stack.
@@ -638,10 +621,16 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. <ins>Otherwise,</ins>
           1. <ins>Let _capability_ be ! NewPromiseCapability(%Promise%).</ins>
           1. <ins>Perform ! AsyncBlockStart(_capability_, _module_.[[ECMAScriptCode]], _moduleCxt_).</ins>
-          1. <ins>Let _stepsFulfilled_ be the steps of _AsyncExecutionFulfilled_.</ins>
+          1. <ins>Let _stepsFulfilled_ be the following steps</ins>
+            1. <ins>Let _F_ be the active function object.</ins>
+            1. <ins>Let _module_ be _F_.[[Module]].</ins>
+            1. <ins>Perform ! AsyncExecutionFulfilled(_module_).</ins>
           1. <ins>Let _onFulfilled_ be CreateBuiltinFunction(_stepsFulfilled_, &laquo; [[Module]] &raquo;).</ins>
           1. <ins>Set _onFulfilled_.[[Module]] to _module_.</ins>
-          1. <ins>Let _stepsRejected_ be the steps of _AsyncExecutionRejected_.</ins>
+          1. <ins>Let _stepsRejected_ be the following steps with argument _error_</ins>
+            1. <ins>Let _F_ be the active function object.</ins>
+            1. <ins>Let _module_ be _F_.[[Module]].</ins>
+            1. <ins>Perform ! AsyncExecutionRejected(_module_, _error_).</ins>
           1. <ins>Let _onRejected_ be CreateBuiltinFunction(_stepsRejected_, &laquo; [[Module]] &raquo;).</ins>
           1. <ins>Set _onRejected_.[[Module]] to _module_.</ins>
           1. <ins>Perform ! PerformPromiseThen(_capability_.[[Promise]], _onFulfilled_, _onRejected_).</ins>

--- a/spec.html
+++ b/spec.html
@@ -461,6 +461,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. Set _module_.[[DFSIndex]] to _index_.
         1. Set _module_.[[DFSAncestorIndex]] to _index_.
         1. <ins>Set _module_.[[PendingAsyncDependencies]] to 0.</ins>
+        1. <ins>Set _requiredModule_.[[AsyncParentModules]] to a new empty List.</ins>
         1. Set _index_ to _index_ + 1.
         1. Append _module_ to _stack_.
         1. For each String _required_ that is an element of _module_.[[RequestedModules]], do
@@ -475,8 +476,6 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
           1. <ins>Otherwise, set _requiredModule_ to GetAsyncCycleRoot(_requiredModule_).</ins>
           1. <ins>If _requiredModule_.[[Status]] is `"evaluating-async"`, then</ins>
             1. <ins>Set _module_.[[PendingAsyncDependencies]] to _module_.[[PendingAsyncDependencies]] + 1.</ins>
-            1. <ins>If _requiredModule_.[[AsyncParentModules]]_ is *undefined*, then</ins>
-              1. <ins>Set _requiredModule_.[[AsyncParentModules]] to a new empty List.</ins>
             1. <ins>Append _module_ to _requiredModule.[[AsyncParentModules]]_.</ins>
         1. <ins>If _module_.[[PendingAsyncDependencies]] is 0, then</ins>
           1. Perform ? _module_.ExecuteModule()

--- a/spec.html
+++ b/spec.html
@@ -433,9 +433,8 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
           1. Set _m_.[[Status]] to `"evaluated"`.
           1. Set _m_.[[EvaluationError]] to _result_.
         1. Assert: _module_.[[Status]] is `"evaluated"` and _module_.[[EvaluationError]] is _result_.
-        1. <del>Return _result_.</del>
         1. <ins>Perform ! Call(_module_.[[TopLevelCapability]].[[Reject]], *undefined*, &laquo;_result_.[[Value]]&raquo;).</ins>
-        1. <ins>Return _capability_.[[Promise]].</ins>
+        1. Return <del>_result_</del><ins>_capability_.[[Promise]]</ins>.
       1. Assert: _module_.[[Status]] is `"evaluated"`<ins> or `"evaluating-async"`</ins><del> and _module_.[[EvaluationError]] is *undefined*</del>.
       1. Assert: _stack_ is empty.
       1. Return <del>*undefined*</del><ins>_capability_.[[Promise]]</ins>.

--- a/spec.html
+++ b/spec.html
@@ -526,6 +526,8 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
           1. Decrement _m_.[[PendingAsyncDependencies]] by 1.
           1. If _m_.[[PendingAsyncDependencies]] is 0 and _m_.[[EvaluationError]] is *undefined*, then
             1. Assert _m_.[[Status]] is `"evaluating-async"`.
+            1. Let _cycleRoot_ be ! GetCycleRoot(_m_).
+            1. If _cycleRoot_.[[EvaluationError]] is not *undefined*, return *undefined*.
             1. Perform ! _module_.ExecuteModule().
         1. If _module_.[[TopLevelCapability]] is not *undefined*, then
           1. Assert: _module_.[[DFSIndex]] is equal to _module_.[[DFSAncestorIndex]].

--- a/spec.html
+++ b/spec.html
@@ -420,7 +420,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
     <emu-alg>
       1. Let _module_ be this Source Text Module Record.
       1. Assert: _module_.[[Status]] is `"instantiated"`<ins>, `"evaluating-async"`</ins> or `"evaluated"`.
-      1. <ins>If _module_.[[Status]] is `"evaluated"` or `"evaluating-async"`, set _module_ to GetAsyncCycleRoot(_module_).</ins>
+      1. <ins>If _module_.[[Status]] is `"evaluated"` or `"evaluating-async"`, set _module_ to GetCycleRoot(_module_).</ins>
       1. <ins>If _module_.[[TopLevelCapability]] is not *undefined*, then</ins>
         1. <ins>Return _module_.[[TopLevelCapability]].</ins>
       1. Let _stack_ be a new empty List.
@@ -473,7 +473,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
           1. If _requiredModule_.[[Status]] is `"evaluating"`, then
             1. Assert: _requiredModule_ is a Cyclic Module Record.
             1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
-          1. <ins>Otherwise, set _requiredModule_ to GetAsyncCycleRoot(_requiredModule_).</ins>
+          1. <ins>Otherwise, set _requiredModule_ to GetCycleRoot(_requiredModule_).</ins>
           1. <ins>If _requiredModule_.[[Status]] is `"evaluating-async"`, then</ins>
             1. <ins>Set _module_.[[PendingAsyncDependencies]] to _module_.[[PendingAsyncDependencies]] + 1.</ins>
             1. <ins>Append _module_ to _requiredModule.[[AsyncParentModules]]_.</ins>
@@ -497,12 +497,12 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         <p><ins>A module is `"evaluating"` while it is being traversed by InnerModuleEvaluation. A module is `"evaluated"` on execution completion, and `"evaluating-async"` during execution if it is an asynchronous module.</ins></p>
       </emu-note>
       <emu-note>
-        <p><ins>Any modules depending on a module of an async cycle when that cycle is not `"evaluating"` will instead depend on the execution of the root of the cycle via GetAsyncCycleRoot. This ensures that the cycle state can be treated as a single strongly connected component through its root module state.</ins></p>
+        <p><ins>Any modules depending on a module of an async cycle when that cycle is not `"evaluating"` will instead depend on the execution of the root of the cycle via GetCycleRoot. This ensures that the cycle state can be treated as a single strongly connected component through its root module state.</ins></p>
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-getasynccycleroot" aoid="GetAsyncCycleRoot">
-      <h1><ins>GetAsyncCycleRoot ( _module_ )</ins></h1>
+    <emu-clause id="sec-getcycleroot" aoid="GetCycleRoot">
+      <h1><ins>GetCycleRoot ( _module_ )</ins></h1>
       <emu-alg>
         1. Repeat, while _module_.[[DFSIndex]] is greater than _module_.[[DFSAncestorIndex]],
           1. Assert: _module_.[[AsyncParentModules]] is a non-empty List.

--- a/spec.html
+++ b/spec.html
@@ -294,7 +294,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         </tr>
         <tr>
           <td>
-            <ins>[[AsyncParentModules]]</ins>
+            <ins>[[AsyncExecParent]]</ins>
           </td>
           <td>
             <ins>List of Cyclic Module Record | *undefined*</ins>
@@ -434,7 +434,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
       1. Let _module_ be this Source Text Module Record.
       1. Assert: _module_.[[Status]] is `"instantiated"`, <ins>`"evaluating-async"`</ins> or `"evaluated"`.
       1. Let _stack_ be a new empty List.
-      1. Let _result_ be InnerModuleEvaluation(_module_, _stack_, 0).
+      1. Let _result_ be InnerModuleEvaluation(_module_, <ins>*undefined*</ins>_stack_, 0).
       1. If _result_ is an abrupt completion, then
         1. For each module _m_ in _stack_, do
           1. Assert: _m_.[[Status]] is `"evaluating"`.
@@ -449,7 +449,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
     </emu-alg>
 
     <emu-clause id="sec-innermoduleevaluation" aoid="InnerModuleEvaluation">
-      <h1>InnerModuleEvaluation( _module_, _stack_, _index_ )</h1>
+      <h1>InnerModuleEvaluation( _module_, <ins>_parent_, </ins>_stack_, _index_ )</h1>
 
       <p>The InnerModuleEvaluation abstract operation is used by Evaluate to perform the actual evaluation process for the Cyclic Module Record _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSIndex]] and [[DFSAncestoreIndex]] fields, are used the same way as in InnerModuleInstantiation.</p>
 
@@ -459,17 +459,30 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. If _module_ is not a Source Text Module Record, then
           1. Perform _module_.Evaluate().
           1. Return _index_.
-        1. If _module_.[[Status]] is `"evaluated"` <ins> or `"evaluating-async"`</ins>, then
+        1. If _module_.[[Status]] is `"evaluated"`, then
           1. If _module_.[[EvaluationError]] is *undefined*, return _index_.
           1. Otherwise return _module_.[[EvaluationError]].
+        1. <ins>If _module_.[[Status]] is `"evaluating-async"`, then</ins>
+          1. <ins>Set _parent_.[[PendingAsyncDependencies]]_ to _parent_.[[PendingAsyncDependencies]]_ + 1.</ins>
+          1. <ins>Let _stepsFulfilled_ be the steps of _AsyncExecutionFulfilled_.</ins>
+          1. <ins>Let _onFulfilled_ be CreateBuiltinFunction(_stepsFulfilled_, &laquo; [[Module]] &raquo;).</ins>
+          1. <ins>Set _onFulfilled_.[[Module]] to _requiredModule_.</ins>
+          1. <ins>Let _stepsRejected_ be the steps of _AsyncExecutionRejected_.</ins>
+          1. <ins>Let _onRejected_ be CreateBuiltinFunction(_stepsRejected_, &laquo; [[Module]] &raquo;).</ins>
+          1. <ins>Set _onRejected_.[[Module]] to _requiredModule_.</ins>
+          1. <ins>Set _parent_.[[PendingAsyncDependencies]]_ to _parent_.[[PendingAsyncDependencies]]_ + 1.</ins>
+          1. <ins>Perform ! PerformPromiseThen(_module_.[[EvaluationCapability]].[[Promise]], _onFulfilled_, _onRejected_).</ins></ins>
+          1. <ins>Return *undefined*.</ins>
         1. If _module_.[[Status]] is `"evaluating"`, return _index_.
         1. Assert: _module_.[[Status]] is `"instantiated"`.
         1. Set _module_.[[Status]] to `"evaluating"`.
         1. Set _module_.[[DFSIndex]] to _index_.
         1. Set _module_.[[DFSAncestorIndex]] to _index_.
         1. <ins>If _module_.[[Async]] is *true*, then</ins>
+          1. <ins>Set _module_.[[AsyncExecParent]] to _parent_.</ins>
+          1. <ins>Set _parent_.[[PendingAsyncDependencies]]_ to _parent_.[[PendingAsyncDependencies]]_ + 1.</ins>
           1. <ins>Set _module_.[[PendingAsyncDependencies]] to 0.</ins>
-          1. <ins>Set _module_.[[AsyncParentModules]] to a new empty List.</ins>
+          1. <ins>Set _module_.[[AsyncExecParent]] to a new empty List.</ins>
           1. <ins>Let _capability_ be ! NewPromiseCapability(%Promise%).</ins>
           1. <ins>Set _module_.[[EvaluationCapability]] to _capability_.</ins>
         1. Set _index_ to _index_ + 1.
@@ -477,26 +490,12 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. For each String _required_ that is an element of _module_.[[RequestedModules]], do
           1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
           1. NOTE: Instantiate must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
-          1. <del>Set _index_ to</del><ins>Let _newIndex_ be </ins> ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_).
+          1. Set _index_ to ? InnerModuleEvaluation(_requiredModule_, <ins>_module_, </ins>_stack_, _index_).
           1. Assert: _requiredModule_.[[Status]] is either `"evaluating"` <ins>`"evaluating-async"`</ins> or `"evaluated"`.
           1. Assert: _requiredModule_.[[Status]] is `"evaluating"` if and only if _requiredModule_ is in _stack_.
           1. If _requiredModule_.[[Status]] is `"evaluating"`, then
             1. Assert: _requiredModule_ is a Cyclic Module Record.
             1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
-          1. <ins>If _requiredModule_.[[Async]] is *true* and _newIndex_ is greater than _index_, then</ins>
-            1. <ins>Set _module_.[[PendingAsyncDependencies]]_ to _module_.[[PendingAsyncDependencies]]_ + 1.</ins>
-            1. <ins>Append _module_ to _requiredModule.[[AsyncParentModules]]_.</ins>
-          1. <ins>Otherwise, if _requiredModule_.[[Status]] is `"evaluating-async"`</ins>
-            1. <ins>Assert: This module execution was initiated by another top-level execution job.</ins>
-            1. <ins>Set _module_.[[PendingAsyncDependencies]]_ to _module_.[[PendingAsyncDependencies]]_ + 1.</ins>
-            1. <ins>Let _stepsFulfilled_ be the steps of _AsyncExecutionFulfilled_.</ins>
-            1. <ins>Let _onFulfilled_ be CreateBuiltinFunction(_stepsFulfilled_, &laquo; [[Module]] &raquo;).</ins>
-            1. <ins>Set _onFulfilled_.[[Module]] to _requiredModule_.</ins>
-            1. <ins>Let _stepsRejected_ be the steps of _AsyncExecutionRejected_.</ins>
-            1. <ins>Let _onRejected_ be CreateBuiltinFunction(_stepsRejected_, &laquo; [[Module]] &raquo;).</ins>
-            1. <ins>Set _onRejected_.[[Module]] to _requiredModule_.</ins>
-            1. <ins>Perform ! PerformPromiseThen(_requiredModule_.[[EvaluationCapability]].[[Promise]], _onFulfilled_, _onRejected_).</ins></ins>
-          1. <ins>Set _index_ to _newIndex_.</ins>
         1. <ins>If _module_.[[Async]] is *false* or the length of _module_.[[PendingAsyncDependencies]] is 0, then</ins>
           1. Perform ? _module_.ExecuteModule()
         1. Assert: _module_ occurs exactly once in _stack_.
@@ -525,11 +524,12 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. Let _module_ be _f_.[[Module]].
         1. Assert: _module_.[[Status]] is `"evaluating-async"`.
         1. Set _module_.[[Status]] to `"evaluated"`.
-        1. For each Module _m_ of _module_.[[AsyncParentModules]], do
-          1. Decrement _m_.[[PendingAsyncDependencies]] by 1.
-          1. If _m_.[[PendingAsyncDependencies]] is 0 and _m_.[[EvaluationError]] is *undefined*, then
-            1. Assert _m_.[[Status]] is `"evaluating-async"`.
-            1. Perform ! _module_.ExecuteModule().
+        1. Let _execParent_ be _module_.[[AsyncParent]].
+        1. If _execParent_ is not *undefined*, then
+          1. Decrement _execParent_.[[PendingAsyncDependencies]] by 1.
+          1. If _execParent_.[[PendingAsyncDependencies]] is 0 and _execParent_.[[EvaluationError]] is *undefined*, then
+            1. Assert _execParent_.[[Status]] is `"evaluating-async"`.
+            1. Perform ! _execParent_.ExecuteModule().
         1. If _module_.[[DFSAncestorIndex]] equals _module_.[[DFSIndex]], then
           1. Perform ! Call(_module_.[[EvaluationCapability]].[[Resolve]], *undefined*, &laquo;*undefined*&raquo;).
         1. Return *undefined*.
@@ -548,11 +548,12 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. Assert: _module_.[[EvaluationError]] is *undefined*.
         1. Set _module_.[[Status]] to `"evaluated"`.
         1. Set _module_.[[EvaluationError]] to ThrowCompletion(_error_).
-        1. For each Module _m_ of _module_.[[AsyncParentModules]], do
-          1. If _m_.[[Status]] is `"evaluating-async"`, then
+        1. Let _execParent_ be _module_.[[AsyncParent]].
+        1. If _execParent_ is not *undefined*, then
+          1. If _execParent_.[[Status]] is `"evaluating-async"`, then
             1. Let _stepsRejected_ be the steps of _AsyncExecutionRejected_.
             1. Let _parentRejected_ be CreateBuiltinFunction(_stepsRejected_, &laquo; [[Module]] &raquo;).
-            1. Set _parentRejected_.[[Module]] to _m_.
+            1. Set _parentRejected_.[[Module]] to _execParent_.
             1. Perform ! Call(_parentRejected_, *undefined*, &laquo; _error_ &raquo;).
         1. Perform ! Call(_module_.[[EvaluationCapability]].[[Reject]], *undefined*, &laquo;_error_&raquo;).
         1. Return *undefined*.
@@ -594,7 +595,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. Else,
           1. Append _ee_ to _indirectExportEntries_.
       1. <ins>Let _async_ be _body_ Contains |AwaitExpression|.</ins>
-      1. Return Source Text Module Record { [[Realm]]: _realm_, [[Environment]]: *undefined*, [[Namespace]]: *undefined*, <ins>[[Async]]: _async_, [[EvaluationCapability]]: *undefined*, [[AsyncParentModules]]: *undefined*, [[PendingAsyncDependencies]]: *undefined*, </ins>[[Status]]: `"uninstantiated"`, [[EvaluationError]]: *undefined*, [[HostDefined]]: _hostDefined_, [[ECMAScriptCode]]: _body_, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[DFSIndex]]: *undefined*, [[DFSAncestorIndex]]: *undefined*, <ins>[[ModuleAsync]]: _async_</ins> }.
+      1. Return Source Text Module Record { [[Realm]]: _realm_, [[Environment]]: *undefined*, [[Namespace]]: *undefined*, <ins>[[Async]]: _async_, [[EvaluationCapability]]: *undefined*, [[AsyncExecParent]]: *undefined*, [[PendingAsyncDependencies]]: *undefined*, </ins>[[Status]]: `"uninstantiated"`, [[EvaluationError]]: *undefined*, [[HostDefined]]: _hostDefined_, [[ECMAScriptCode]]: _body_, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[DFSIndex]]: *undefined*, [[DFSAncestorIndex]]: *undefined*, <ins>[[ModuleAsync]]: _async_</ins> }.
     </emu-alg>
     <emu-note>
       <p>An implementation may parse module source text and analyse it for Early Error conditions prior to the evaluation of ParseModule for that module source text. However, the reporting of any errors must be deferred until the point where this specification actually performs ParseModule upon that source text.</p>

--- a/spec.html
+++ b/spec.html
@@ -305,17 +305,6 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         </tr>
         <tr>
           <td>
-            <ins>[[DirectEvaluationCapability]]</ins>
-          </td>
-          <td>
-            <ins>Promise Capability Record | *undefined*</ins>
-          </td>
-          <td>
-            <ins>If [[Async]] is true and execution has started, this tracks the direct execution promise for the module.</ins>
-          </td>
-        </tr>
-        <tr>
-          <td>
             <ins>[[PendingAsyncDependencies]]</ins>
           </td>
           <td>
@@ -480,13 +469,24 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. Set _module_.[[DFSAncestorIndex]] to _index_.
         1. Set _index_ to _index_ + 1.
         1. Append _module_ to _stack_.
-        1. <ins>Let _pendingAsyncDependencies_ be an empty List.</ins>
+        1. <ins>Let _pendingAsyncDependencies_ be 0.</ins>
         1. For each String _required_ that is an element of _module_.[[RequestedModules]], do
           1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
           1. NOTE: Instantiate must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
-          1. <ins>If _requiredModule_.[[Async]] is *true*, _requiredModule_.[[Status]] is not `"evaluated"` and _pendingAsyncDependencies_ does not contain _requiredModule_, then</ins>
-            1. <ins>Append _requiredModule_ to _pendingAsyncDependencies_.</ins>
-            1. <ins>Append _module_ to _requiredModule_.[[AsyncParentModules]].</ins>
+          1. <ins>If _requiredModule_.[[Async]] is *true*, then</ins>
+            1. <ins>If _requiredModule_.[[Status]] is `"instantiated"`, then</ins>
+              1. <ins>Set _pendingAsyncDependencies_ to _pendingAsyncDependencies_ + 1.</ins>
+              1. <ins>Append _module_ to _requiredModule.[[AsyncParentModules]]_.</ins>
+            1. <ins>Otherwise if _requiredModule_.[[Status]] is `"evaluating-async"`</ins>
+              1. <ins>Assert: This module execution was initiated by another top-level execution job.</ins>
+              1. <ins>Set _pendingAsyncDependencies_ to _pendingAsyncDependencies_ + 1.</ins>
+              1. <ins>Let _stepsFulfilled_ be the steps of _AsyncExecutionFulfilled_.</ins>
+              1. <ins>Let _onFulfilled_ be CreateBuiltinFunction(_stepsFulfilled_, &laquo; [[Module]] &raquo;).</ins>
+              1. <ins>Set _onFulfilled_.[[Module]] to _requiredModule_.</ins>
+              1. <ins>Let _stepsRejected_ be the steps of _AsyncExecutionRejected_.</ins>
+              1. <ins>Let _onRejected_ be CreateBuiltinFunction(_stepsRejected_, &laquo; [[Module]] &raquo;).</ins>
+              1. <ins>Set _onRejected_.[[Module]] to _requiredModule_.</ins>
+              1. <ins>Perform ! PerformPromiseThen(_requiredModule_.[[EvaluationCapability]].[[Promise]], _onFulfilled_, _onRejected_).</ins>
           1. Set _index_ to ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_).
           1. Assert: _requiredModule_.[[Status]] is either `"evaluating"` <ins>`"evaluating-async"`</ins> or `"evaluated"`.
           1. Assert: _requiredModule_.[[Status]] is `"evaluating"` if and only if _requiredModule_ is in _stack_.
@@ -499,10 +499,9 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
           1. <ins>Set _module_.[[AsyncParentModules]] to a new empty List.</ins>
           1. <ins>Set _module_.[[PendingAsyncDependencies]] to the length of _pendingAsyncDependencies_.</ins>
           1. <ins>Let _capability_ be ! NewPromiseCapability(%Promise%).</ins>
-          1. <ins>Set _module_.[[DirectEvaluationCapability]] to _capability_.</ins>
           1. <ins>Set _module_.[[EvaluationCapability]] to _capability_.</ins>
           1. <ins>If the length of _pendingAsyncDependencies_ is 0, then</ins>
-            1. <ins>Perform ! _module_.ExecuteModule(_module_.[[DirectEvaluationCapability]]).</ins>
+            1. <ins>Perform ! _module_.ExecuteModule().</ins>
         1. Assert: _module_ occurs exactly once in _stack_.
         1. Assert: _module_.[[DFSAncestorIndex]] is less than or equal to _module_.[[DFSIndex]].
         1. If _module_.[[DFSAncestorIndex]] equals _module_.[[DFSIndex]], then
@@ -533,7 +532,9 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
           1. Decrement _m_.[[PendingAsyncDependencies]] by 1.
           1. If _m_.[[PendingAsyncDependencies]] is 0 and _m_.[[EvaluationError]] is *undefined*, then
             1. Assert _m_.[[Status]] is `"evaluating-async"`.
-            1. Perform ! _module_.ExecuteModule(_module_.[[DirectEvaluationCapability]]).
+            1. Perform ! _module_.ExecuteModule().
+        1. If _module_.[[DFSAncestorIndex]] equals _module_.[[DFSIndex]], then
+          1. Perform ! Call(_module_.[[EvaluationCapability]].[[Resolve]], *undefined*, &laquo;*undefined*&raquo;).
         1. Return *undefined*.
       </emu-alg>
       <emu-note>
@@ -552,8 +553,11 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. Set _module_.[[EvaluationError]] to ThrowCompletion(_error_).
         1. For each Module _m_ of _module_.[[AsyncParentModules]], do
           1. If _m_.[[Status]] is `"evaluating-async"`, then
-            1. Set _m_.[[EvaluationError]] to ThrowCompletion(_error_).
-            1. Perform ! Call(_m_.[[DirectEvaluationCapability]].[[Reject]], *undefined*, &laquo;_error_&raquo;).
+            1. Let _stepsRejected_ be the steps of _AsyncExecutionRejected_.
+            1. Let _parentRejected_ be CreateBuiltinFunction(_stepsRejected_, &laquo; [[Module]] &raquo;).
+            1. Set _parentRejected_.[[Module]] to _m_.
+            1. Perform ! Call(_parentRejected_, *undefined*, &laquo; _error_ &raquo;).
+        1. Perform ! Call(_module_.[[EvaluationCapability]].[[Reject]], *undefined*, &laquo;_error_&raquo;).
         1. Return *undefined*.
       </emu-alg>
     </emu-clause>
@@ -593,7 +597,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. Else,
           1. Append _ee_ to _indirectExportEntries_.
       1. <ins>Let _async_ be _body_ Contains |AwaitExpression|.</ins>
-      1. Return Source Text Module Record { [[Realm]]: _realm_, [[Environment]]: *undefined*, [[Namespace]]: *undefined*, <ins>[[Async]]: _async_, [[EvaluationCapability]]: *undefined*, [[DirectEvaluationCapability]]: *undefined*, [[AsyncParentModules]]: *undefined*, [[PendingAsyncDependencies]]: *undefined*, </ins>[[Status]]: `"uninstantiated"`, [[EvaluationError]]: *undefined*, [[HostDefined]]: _hostDefined_, [[ECMAScriptCode]]: _body_, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[DFSIndex]]: *undefined*, [[DFSAncestorIndex]]: *undefined*, <ins>[[ModuleAsync]]: _async_</ins> }.
+      1. Return Source Text Module Record { [[Realm]]: _realm_, [[Environment]]: *undefined*, [[Namespace]]: *undefined*, <ins>[[Async]]: _async_, [[EvaluationCapability]]: *undefined*, [[AsyncParentModules]]: *undefined*, [[PendingAsyncDependencies]]: *undefined*, </ins>[[Status]]: `"uninstantiated"`, [[EvaluationError]]: *undefined*, [[HostDefined]]: _hostDefined_, [[ECMAScriptCode]]: _body_, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[DFSIndex]]: *undefined*, [[DFSAncestorIndex]]: *undefined*, <ins>[[ModuleAsync]]: _async_</ins> }.
     </emu-alg>
     <emu-note>
       <p>An implementation may parse module source text and analyse it for Early Error conditions prior to the evaluation of ParseModule for that module source text. However, the reporting of any errors must be deferred until the point where this specification actually performs ParseModule upon that source text.</p>
@@ -602,7 +606,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
 
 
     <emu-clause id="sec-source-text-module-record-execute-module" aoid="ExecuteModule">
-      <h1>ExecuteModule ( [ <ins>_capability_</ins> ] )</h1>
+      <h1>ExecuteModule ( )</h1>
 
       <p>The ExecuteModule concrete method of a Source Text Module Record implements the corresponding Cyclic Module Record abstract method.</p>
 
@@ -617,14 +621,13 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. Set the LexicalEnvironment of _moduleCxt_ to _module_.[[Environment]].
         1. Suspend the currently running execution context.
         1. <ins>If _module_.[[ModuleAsync]] is *false*, then</ins>
-          1. <ins>Assert: _capability_ was not provided.</ins>
           1. Push _moduleCxt_ on to the execution context stack; _moduleCxt_ is now the running execution context.
           1. Let _result_ be the result of evaluating _module_.[[ECMAScriptCode]].
           1. Suspend _moduleCxt_ and remove it from the execution context stack.
           1. Resume the context that is now on the top of the execution context stack as the running execution context.
           1. Return Completion(_result_).
         1. <ins>Otherwise,</ins>
-          1. <ins>Assert: _capability_ was provided.</ins>
+          1. <ins>Let _capability_ be ! NewPromiseCapability(%Promise%).</ins>
           1. <ins>Perform ! AsyncBlockStart(_capability_, _module_.[[ECMAScriptCode]], _moduleCxt_).</ins>
           1. <ins>Let _stepsFulfilled_ be the steps of _AsyncExecutionFulfilled_.</ins>
           1. <ins>Let _onFulfilled_ be CreateBuiltinFunction(_stepsFulfilled_, &laquo; [[Module]] &raquo;).</ins>


### PR DESCRIPTION
This revises the parent execution ordering fix for https://github.com/tc39/proposal-top-level-await/issues/64 (previously https://github.com/tc39/proposal-top-level-await/pull/71), while also ensuring that cycles transition in a well-defined way.

This retains the parent chain execution semantics when an asynchronous dependency is added, without causing any execution ordering changes. For example with this approach, sync modules can provide polyfills that will execute before async dependencies in order. The spec diff has simplified down quite a lot in the process.

Consider for example:

main.js
```js
import './dep.js';
console.log('main');
```

dep.js
```js
console.log('dep');
Promise.resolve().then(() => {
  console.log('dep task');
});
```

the log when importing main is `"dep", "main", "dep task"`.

If we add a dependency to `dep.js` that does not use top-level await, we retain the `"dep", "main", "dep task"` ordering.

But if we add an async dependency to `dep.js`:

dep.js
```js
import 'async-dep';
console.log('dep');
Promise.resolve().then(() => {
  console.log('dep task');
});
```

then the ordering becomes `"async-dep", "dep", "dep task", "main"`.

The problem with the above is that the timing of the parent modules relative to eachother is changed by introducing an async dependency.

This PR resolves that so that the execution semantics of the parent ordering and timings remains the same, to provide the output `"async-dep", "dep", "main", "dep-task"`.

This is achieved with global completion handlers on module execution that manage the graph state transitions.