### PR TITLE
Normative: Execution initialization handling

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -484,7 +484,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. <del>Perform ? _module_.ExecuteModule().</del>
         1. <ins>If _module_.[[PendingAsyncDependencies]] is 0, then</ins>
           1. <ins>If _module_.[[Async]] is *false*, then</ins>
-            1. <ins></ins>Perform ? _module_.ExecuteModule().
+            1. <ins>Perform ? _module_.ExecuteModule().</ins>
             1. <ins>Perform ! CyclicModuleExecutionFulfilled(module).</ins>
           1. <ins>Otherwise,
             1. <ins>Perform ! ExecuteCyclicModule(_module_).</ins>

--- a/spec.html
+++ b/spec.html
@@ -487,7 +487,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. <ins>If _module_.[[PendingAsyncDependencies]] is 0, then</ins>
           1. <ins>If _module_.[[Async]] is *false*, then</ins>
             1. <ins>Perform ? _module_.ExecuteModule().</ins>
-            1. <ins>1. If _module_.[[TopLevelCapability]] is not *undefined*, then</ins>
+            1. <ins>If _module_.[[TopLevelCapability]] is not *undefined*, then</ins>
               1. <ins>Assert: _module_.[[DFSIndex]] is equal to _module_.[[DFSAncestorIndex]].</ins>
               1. <ins>Perform ! Call(_module_.[[TopLevelCapability]].[[Resolve]], *undefined*, &laquo;*undefined*&raquo;).</ins>
           1. <ins>Otherwise,

--- a/spec.html
+++ b/spec.html
@@ -481,9 +481,13 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
             1. <ins>If _requiredModule_.[[Status]] is `"evaluating-async"`, then</ins>
               1. <ins>Set _module_.[[PendingAsyncDependencies]] to _module_.[[PendingAsyncDependencies]] + 1.</ins>
               1. <ins>Append _module_ to _requiredModule_.[[AsyncParentModules]].</ins>
-        1. <del>Perform ? _module_.ExecuteModule().</del>
         1. <ins>If _module_.[[PendingAsyncDependencies]] is 0, then</ins>
-          1. <ins>Perform ! ExecuteCyclicModule(_module_).</ins>
+          1. <ins>If _module_.[[Async]] is *false*, then</ins>
+            1. Perform ? _module_.ExecuteModule().
+            1. <ins>Perform ! CyclicModuleExecutionFulfilled(module).</ins>
+          1. <ins>Otherwise,
+            1. <ins>Perform ! ExecuteCyclicModule(_module_).</ins>
+            1. <ins>Set _module_.[[Status]] to `"evaluating-async"`.</ins>
           1. <ins>If _module_.[[EvaluationError]] is not *undefined*, return _module_.[[EvaluationError]].</ins>
         1. Assert: _module_ occurs exactly once in _stack_.
         1. Assert: _module_.[[DFSAncestorIndex]] is less than or equal to _module_.[[DFSIndex]].
@@ -493,9 +497,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
             1. Let _requiredModule_ be the last element in _stack_.
             1. Remove the last element of _stack_.
             1. Assert: _requiredModule_ is a Cyclic Module Record.
-            1. <ins>If _module_.[[Async]] is *true* or _module_.[[PendingAsyncDependencies]] is not 0, then</ins>
-              1. <ins>Set _requiredModule_.[[Status]] to `"evaluating-async"`.</ins>
-            1. <ins>Otherwise, </ins>set _requiredModule_.[[Status]] to `"evaluated"`.
+            1. <ins>If _module_.[[Async]] is *false*, </ins>set _requiredModule_.[[Status]] to `"evaluated"`.
             1. If _requiredModule_ and _module_ are the same Module Record, set _done_ to *true*.
         1. Return _index_.
       </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -473,7 +473,9 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
           1. Set _index_ to ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_).
           1. If _requiredModule_ is a Cyclic Module Record, then
             1. Assert: _requiredModule_.[[Status]] is either `"evaluating"`<ins>, `"evaluating-async"`</ins> or `"evaluated"`.
-            1. Assert: _requiredModule_.[[Status]] is `"evaluating"` if and only if _requiredModule_ is in _stack_.
+            1. <del>Assert: _requiredModule_.[[Status]] is `"evaluating"` if and only if _requiredModule_ is in _stack_.</del>
+            1. <ins>Assert: If _requiredModule_ is in _stack_, then _requiredModule_.[[Status]] is either `"evaluating"` or `"evaluating-async"`.</ins>
+            1. <ins>Assert: If _requiredMdoule_.[[Status]] is `"evaluating"`, then _requireModule_ is in _stack_.</ins>
             1. If _requiredModule_.[[Status]] is `"evaluating"`, then
               1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
             1. <ins>Otherwise, set _requiredModule_ to GetCycleRoot(_requiredModule_).</ins>

--- a/spec.html
+++ b/spec.html
@@ -481,9 +481,10 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
             1. <ins>If _requiredModule_.[[Status]] is `"evaluating-async"`, then</ins>
               1. <ins>Set _module_.[[PendingAsyncDependencies]] to _module_.[[PendingAsyncDependencies]] + 1.</ins>
               1. <ins>Append _module_ to _requiredModule_.[[AsyncParentModules]].</ins>
+        1. <del>Perform ? _module_.ExecuteModule().</del>
         1. <ins>If _module_.[[PendingAsyncDependencies]] is 0, then</ins>
           1. <ins>If _module_.[[Async]] is *false*, then</ins>
-            1. Perform ? _module_.ExecuteModule().
+            1. <ins></ins>Perform ? _module_.ExecuteModule().
             1. <ins>Perform ! CyclicModuleExecutionFulfilled(module).</ins>
           1. <ins>Otherwise,
             1. <ins>Perform ! ExecuteCyclicModule(_module_).</ins>
@@ -497,7 +498,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
             1. Let _requiredModule_ be the last element in _stack_.
             1. Remove the last element of _stack_.
             1. Assert: _requiredModule_ is a Cyclic Module Record.
-            1. <ins>If _module_.[[Async]] is *false*, </ins>set _requiredModule_.[[Status]] to `"evaluated"`.
+            1. <ins>If _module_.[[Async]] is *false* and _module_.[[PendingAsyncDependencies]] is 0, </ins>set _requiredModule_.[[Status]] to `"evaluated"`.
             1. If _requiredModule_ and _module_ are the same Module Record, set _done_ to *true*.
         1. Return _index_.
       </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -475,7 +475,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
             1. Assert: _requiredModule_.[[Status]] is either `"evaluating"`<ins>, `"evaluating-async"`</ins> or `"evaluated"`.
             1. <del>Assert: _requiredModule_.[[Status]] is `"evaluating"` if and only if _requiredModule_ is in _stack_.</del>
             1. <ins>Assert: If _requiredModule_ is in _stack_, then _requiredModule_.[[Status]] is either `"evaluating"` or `"evaluating-async"`.</ins>
-            1. <ins>Assert: If _requiredMdoule_.[[Status]] is `"evaluating"`, then _requireModule_ is in _stack_.</ins>
+            1. <ins>Assert: If _requiredModule_.[[Status]] is `"evaluating"`, then _requiredModule_ is in _stack_.</ins>
             1. If _requiredModule_.[[Status]] is `"evaluating"`, then
               1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
             1. <ins>Otherwise, set _requiredModule_ to GetCycleRoot(_requiredModule_).</ins>

--- a/spec.html
+++ b/spec.html
@@ -556,7 +556,8 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
       <h1><ins>CyclicModuleExecutionFulfilled ( _module_ )</ins></h1>
       <emu-alg>
         1. Assert: _module_.[[EvaluationError]] is *undefined*.
-        1. If _module_.[[Status]] is `"instantiating"`, then
+        1. Assert: _module_.[[Status]] is `"evaluating"`, `"evaluating-async"` or `"evaluated"`.
+        1. If _module_.[[Status]] is `"evaluating"`, then
           1. Assert: _module_.[[Async]] is *false*.
           1. Assert: _module_.[[AsyncParentModules]] is an empty List.
         1. If _module_.[[Status]] is `"evaluating-async"`, then
@@ -581,9 +582,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
       <h1><ins>CyclicModuleExecutionRejected ( _module_, _error_ )</ins></h1>
       <emu-alg>
         1. Assert: _module_.[[EvaluationError]] is *undefined*.
-        1. If _module_.[[Status]] is `"instantiating"`, then
-          1. Assert: _module_.[[Async]] is *false*.
-          1. Assert: _module_.[[AsyncParentModules]] is an empty List.
+        1. Assert: _module_.[[Status]] is `"evaluating-async"` or `"evaluated"`.
         1. If _module_.[[Status]] is `"evaluating-async"`, then
           1. Set _module_.[[Status]] to `"evaluated"`.
         1. Set _module_.[[EvaluationError]] to ThrowCompletion(_error_).

--- a/spec.html
+++ b/spec.html
@@ -487,7 +487,9 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. <ins>If _module_.[[PendingAsyncDependencies]] is 0, then</ins>
           1. <ins>If _module_.[[Async]] is *false*, then</ins>
             1. <ins>Perform ? _module_.ExecuteModule().</ins>
-            1. <ins>Perform ! CyclicModuleExecutionFulfilled(module).</ins>
+            1. <ins>1. If _module_.[[TopLevelCapability]] is not *undefined*, then</ins>
+              1. <ins>Assert: _module_.[[DFSIndex]] is equal to _module_.[[DFSAncestorIndex]].</ins>
+              1. <ins>Perform ! Call(_module_.[[TopLevelCapability]].[[Resolve]], *undefined*, &laquo;*undefined*&raquo;).</ins>
           1. <ins>Otherwise,
             1. <ins>Perform ! ExecuteCyclicModule(_module_).</ins>
             1. <ins>Set _module_.[[Status]] to `"evaluating-async"`.</ins>
@@ -558,12 +560,8 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
       <h1><ins>CyclicModuleExecutionFulfilled ( _module_ )</ins></h1>
       <emu-alg>
         1. Assert: _module_.[[EvaluationError]] is *undefined*.
-        1. Assert: _module_.[[Status]] is `"evaluating"`, `"evaluating-async"` or `"evaluated"`.
-        1. If _module_.[[Status]] is `"evaluating"`, then
-          1. Assert: _module_.[[Async]] is *false*.
-          1. Assert: _module_.[[AsyncParentModules]] is an empty List.
-        1. If _module_.[[Status]] is `"evaluating-async"`, then
-          1. Set _module_.[[Status]] to `"evaluated"`.
+        1. Assert: _module_.[[Status]] is `"evaluating-async"`.
+        1. Set _module_.[[Status]] to `"evaluated"`.
         1. For each Module _m_ of _module_.[[AsyncParentModules]], do
           1. If _module_.[[DFSIndex]] is not equal to _module_.[[DFSAncestorIndex]], then
             1. Assert: _m_.[[DFSAncestorIndex]] is equal to _module_.[[DFSAncestorIndex]].


### PR DESCRIPTION
This addresses #84 and #89 by:

1. Ensuring that we separate the direct sync execution handling as its own ExecuteModule call which will propagate the abrupt completions (unlike ExecuteCyclicModule).

2. Moving the progressive state transitions into `"evaluating-async"` to not be strongly connected component transitions to properly support the progressive loading of a cycle. Note also that this remains well defined despite the state transition being gradual because of the use of GetCycleRoot whenever a "evaluating-async" status is encountered.