### PR TITLE
Normative: Check for correct module state

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -553,7 +553,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
       <h1><ins>CyclicModuleExecutionFulfilled ( _module_ )</ins></h1>
       <emu-alg>
         1. Assert: _module_.[[EvaluationError]] is *undefined*.
-        1. If _module_.[[Status]] is `"instantiating"`, then
+        1. If _module_.[[Status]] is `"evaluating"`, then
           1. Assert: _module_.[[Async]] is *false*.
           1. Assert: _module_.[[AsyncParentModules]] is an empty List.
         1. If _module_.[[Status]] is `"evaluating-async"`, then


### PR DESCRIPTION
In a typo, I used "instantiating" where I meant "evaluating".
"instantiating" would never be the state. This patch fixes the error.

Fixes #92