### PR TITLE
Normative: Fix state checking in async cycle case

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -470,6 +470,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. For each String _required_ that is an element of _module_.[[RequestedModules]], do
           1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
           1. NOTE: Instantiate must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
+          1. <ins>Let _cycle_ be *true* if _requiredModule_.[[Status]] is `"evaluating"`, and *false* otherwise.</ins>
           1. Set _index_ to ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_).
           1. If _requiredModule_ is a Cyclic Module Record, then
             1. Assert: _requiredModule_.[[Status]] is either `"evaluating"`<ins>, `"evaluating-async"`</ins> or `"evaluated"`.
@@ -478,9 +479,10 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
               1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
             1. <ins>Otherwise, set _requiredModule_ to GetCycleRoot(_requiredModule_).</ins>
             1. <ins>If _requiredModule_.[[EvaluationError]] is not *undefined*, return _module_.[[EvaluationError]].</ins>
-            1. <ins>If _requiredModule_.[[Status]] is `"evaluating-async"`, then</ins>
-              1. <ins>Set _module_.[[PendingAsyncDependencies]] to _module_.[[PendingAsyncDependencies]] + 1.</ins>
-              1. <ins>Append _module_ to _requiredModule_.[[AsyncParentModules]].</ins>
+            1. <ins>If _cycle_ is *false*,</ins>
+              1. <ins>If either _requiredModule_.[[Async]] is *true*, or _requiredModule_.[[PendingAsyncDependencies]] is not 0, then</ins>
+                1. <ins>Set _module_.[[PendingAsyncDependencies]] to _module_.[[PendingAsyncDependencies]] + 1.</ins>
+                1. <ins>Append _module_ to _requiredModule_.[[AsyncParentModules]].</ins>
         1. <del>Perform ? _module_.ExecuteModule().</del>
         1. <ins>If _module_.[[PendingAsyncDependencies]] is 0, then</ins>
           1. <ins>Perform ! ExecuteCyclicModule(_module_).</ins>


### PR DESCRIPTION
If a cycle contains async modules, then its statuses will not be set
to "evaluating-async" until after the cycle is traversed. This could
cause errors in setting up the async dependency graph edges. This PR
uses different checks to avoid the issue.

Fixes #89