### PR TITLE
Editorial: Clarify cycle state variables

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -471,7 +471,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. For each String _required_ that is an element of _module_.[[RequestedModules]], do
           1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
           1. NOTE: Instantiate must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
-          1. <ins>Let _cycle_ be *true* if _requiredModule_.[[Status]] is `"evaluating"`, and *false* otherwise.</ins>
+          1. <ins>Let _cycleEdge_ be *true* if _requiredModule_.[[Status]] is `"evaluating"`, and *false* otherwise.</ins>
           1. Set _index_ to ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_).
           1. If _requiredModule_ is a Cyclic Module Record, then
             1. Assert: _requiredModule_.[[Status]] is either `"evaluating"`<ins>, `"evaluating-async"`</ins> or `"evaluated"`.
@@ -480,7 +480,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
               1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
             1. <ins>Otherwise, set _requiredModule_ to GetCycleRoot(_requiredModule_).</ins>
             1. <ins>If _requiredModule_.[[EvaluationError]] is not *undefined*, return _module_.[[EvaluationError]].</ins>
-            1. <ins>If _cycle_ is *false* and _requiredModule_.[[Status]] is not `"evaluated"`,</ins>
+            1. <ins>If _cycleEdge_ is *false* and _requiredModule_.[[Status]] is not `"evaluated"`,</ins>
               1. <ins>If either _requiredModule_.[[Async]] is *true*, or _requiredModule_.[[PendingAsyncDependencies]] is not 0, then</ins>
                 1. <ins>Set _module_.[[PendingAsyncDependencies]] to _module_.[[PendingAsyncDependencies]] + 1.</ins>
                 1. <ins>Append _module_ to _requiredModule_.[[AsyncParentModules]].</ins>
@@ -494,11 +494,12 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
           1. Let _done_ be *false*.
           1. Repeat, while _done_ is *false*,
             1. Let _requiredModule_ be the last element in _stack_.
+            1. <ins>Let _transitionState_ be `"evaluated"`.</ins>
+            1. <ins>If _module_.[[Async]] is *true* or _module_.[[PendingAsyncDependencies]] is not 0, then</ins>
+              1. <ins>Set _transitionState_ to `"evaluating-async"`.</ins>
             1. Remove the last element of _stack_.
             1. Assert: _requiredModule_ is a Cyclic Module Record.
-            1. <ins>If _module_.[[Async]] is *true* or _module_.[[PendingAsyncDependencies]] is not 0, then</ins>
-              1. <ins>Set _requiredModule_.[[Status]] to `"evaluating-async"`.</ins>
-            1. <ins>Otherwise, </ins>set _requiredModule_.[[Status]] to `"evaluated"`.
+            1. Set _requiredModule_.[[Status]] to <del>`"evaluated"`</del><ins>_transitionState_</ins>.
             1. If _requiredModule_ and _module_ are the same Module Record, set _done_ to *true*.
         1. Return _index_.
       </emu-alg>


### PR DESCRIPTION
Two minor editorial changes to hopefully make the cycle handling clearer -

1. Rename _cycle_ to _cycleEdge_ as added in https://github.com/tc39/proposal-top-level-await/pull/96. I think this will help readability a lot. Other naming suggestion for this "ignored cycle edge" are welcome.
2. In the state transition part of InnerModuleEvaluation, store a single _transitionState_ variable so it is very clear that cycles transition as a single component either into "evaluated" if they have all sync deps, or "evaluating-async" if there is a single async dep in the cycle.