### PR TITLE
Editorial: Inline sync execution handlers

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -515,23 +515,16 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
       <h1><ins>ExecuteAsyncModule ( _module_ )</ins></h1>
       <emu-alg>
         1. Assert: _module_.[[Status]] is `"evaluating"` or `"evaluating-async"`.
-        1. If _module_.[[Async]] is *false*, then:
-          1. Let _result_ be _module_.ExecuteModule().
-          1. If _result_ is a normal completion,
-            1. Perform ! AsyncModuleExecutionFulfilled(_module_).
-          1. Otherwise,
-            1. Perform ! AsyncModuleExecutionRejected(_module_, _result_.[[Value]]).
-        1. Otherwise,
-          1. Let _capability_ be ! NewPromiseCapability(%Promise%).
-          1. Let _stepsFulfilled_ be the steps of a CallCyclicModuleFulfilled function as specified below.
-          1. Let _onFulfilled_ be CreateBuiltinFunction(_stepsFulfilled_, &laquo; [[Module]] &raquo;).
-          1. Set _onFulfilled_.[[Module]] to _module_.
-          1. Let _stepsRejected_ be the steps of a CallCyclicModuleRejected function as specified below.
-          1. Let _onRejected_ be CreateBuiltinFunction(_stepsRejected_, &laquo; [[Module]] &raquo;).
-          1. Set _onRejected_.[[Module]] to _module_.
-          1. Perform ! PerformPromiseThen(_capability_.[[Promise]], _onFulfilled_, _onRejected_).
-          1. Perform ! _module_.ExecuteModule(_capability_).
-          1. Return.
+        1. Let _capability_ be ! NewPromiseCapability(%Promise%).
+        1. Let _stepsFulfilled_ be the steps of a CallCyclicModuleFulfilled function as specified below.
+        1. Let _onFulfilled_ be CreateBuiltinFunction(_stepsFulfilled_, &laquo; [[Module]] &raquo;).
+        1. Set _onFulfilled_.[[Module]] to _module_.
+        1. Let _stepsRejected_ be the steps of a CallCyclicModuleRejected function as specified below.
+        1. Let _onRejected_ be CreateBuiltinFunction(_stepsRejected_, &laquo; [[Module]] &raquo;).
+        1. Set _onRejected_.[[Module]] to _module_.
+        1. Perform ! PerformPromiseThen(_capability_.[[Promise]], _onFulfilled_, _onRejected_).
+        1. Perform ! _module_.ExecuteModule(_capability_).
+        1. Return.
       </emu-alg>
 
       <p>A CallCyclicModuleRejected function is an anonymous built-in function with a [[Module]] internal slot. When a CallCyclicModuleRejeced function is called that expects no arguments it performs the following steps:</p>
@@ -579,7 +572,14 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
             1. Assert: _m_.[[Status]] is `"evaluating-async"`.
             1. Let _cycleRoot_ be ! GetCycleRoot(_m_).
             1. If _cycleRoot_.[[EvaluationError]] is not *undefined*, return *undefined*.
-            1. Perform ! ExecuteAsyncModule(_m_).
+            1. If _module_.[[Async]] is *true*, then
+              1. Perform ! ExecuteAsyncModule(_m_).
+            1. Otherwise,
+              1. Let _result_ be _module_.ExecuteModule().
+              1. If _result_ is a normal completion,
+                1. Perform ! AsyncModuleExecutionFulfilled(_module_).
+              1. Otherwise,
+                1. Perform ! AsyncModuleExecutionRejected(_module_, _result_.[[Value]]).
         1. If _module_.[[TopLevelCapability]] is not *undefined*, then
           1. Assert: _module_.[[DFSIndex]] is equal to _module_.[[DFSAncestorIndex]].
           1. Perform ! Call(_module_.[[TopLevelCapability]].[[Resolve]], *undefined*, &laquo;*undefined*&raquo;).

--- a/spec.html
+++ b/spec.html
@@ -439,7 +439,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
       1. <ins>Otherwise,</ins>
         1. Assert: _module_.[[Status]] is `"evaluated"`<ins> or `"evaluating-async"`</ins> and _module_.[[EvaluationError]] is *undefined*.
         1. <ins>If _module_.[[Status]] is `"evaluated"`, then</ins>
-          1. <ins>Perform ! Call(_module_.[[TopLevelCapability]].[[Resolve]], *undefined*, &laquo;*undefined*&raquo;).</ins>
+          1. <ins>Perform ! Call(_capability_.[[Resolve]], *undefined*, &laquo;*undefined*&raquo;).</ins>
         1. Assert: _stack_ is empty.
       1. Return <del>*undefined*</del><ins>_capability_.[[Promise]]</ins>.
     </emu-alg>
@@ -528,19 +528,19 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. Return.
       </emu-alg>
 
-      <p>A CallAsyncModuleRejected function is an anonymous built-in function with a [[Module]] internal slot. When a CallAsyncModuleRejeced function is called that expects no arguments it performs the following steps:</p>
+      <p>A CallAsyncModuleFulfilled function is an anonymous built-in function with a [[Module]] internal slot. When a CallAsyncModuleFulfilled function is called that expects no arguments it performs the following steps:</p>
       <emu-alg>
         1. Let _f_ be the active function object.
         1. Let _module_ be _f_.[[Module]].
-        1. Perform ! CyclicModuleExecutionFulfilled(_module_).
+        1. Perform ! AsyncModuleExecutionFulfilled(_module_).
         1. Return.
       </emu-alg>
 
-      <p>A CallAsyncModuleFulfilled function is an anonymous built-in function with a [[Module]] internal slot. When a CallAsyncModuleFulfilled function is called with argument _error_ it performs the following steps:</p>
+      <p>A CallAsyncModuleRejected function is an anonymous built-in function with a [[Module]] internal slot. When a CallAsyncModuleRejected function is called with argument _error_ it performs the following steps:</p>
       <emu-alg>
         1. Let _f_ be the active function object.
         1. Let _module_ be _f_.[[Module]].
-        1. Perform ! CyclicModuleExecutionFulfilled(_module_, _error_).
+        1. Perform ! AsyncModuleExecutionRejected(_module_, _error_).
         1. Return.
       </emu-alg>
     </emu-clause>
@@ -562,7 +562,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
     <emu-clause id="sec-asyncmodulexecutionfulfilled" aoid="AsyncModuleExecutionFulfilled">
       <h1><ins>AsyncModuleExecutionFulfilled ( _module_ )</ins></h1>
       <emu-alg>
-        1. Assert: _module_.[[Status]] is `"evaluated"`.
+        1. Assert: _module_.[[Status]] is `"evaluating-async"`.
         1. Assert: _module_.[[EvaluationError]] is *undefined*.
         1. Set _module_.[[Status]] to `"evaluated"`.
         1. For each Module _m_ of _module_.[[AsyncParentModules]], do
@@ -573,14 +573,14 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
             1. Assert: _m_.[[Status]] is `"evaluating-async"`.
             1. Let _cycleRoot_ be ! GetCycleRoot(_m_).
             1. If _cycleRoot_.[[EvaluationError]] is not *undefined*, return *undefined*.
-            1. If _module_.[[Async]] is *true*, then
+            1. If _m_.[[Async]] is *true*, then
               1. Perform ! ExecuteAsyncModule(_m_).
             1. Otherwise,
-              1. Let _result_ be _module_.ExecuteModule().
+              1. Let _result_ be _m_.ExecuteModule().
               1. If _result_ is a normal completion,
-                1. Perform ! AsyncModuleExecutionFulfilled(_module_).
+                1. Perform ! AsyncModuleExecutionFulfilled(_m_).
               1. Otherwise,
-                1. Perform ! AsyncModuleExecutionRejected(_module_, _result_.[[Value]]).
+                1. Perform ! AsyncModuleExecutionRejected(_m_, _result_.[[Value]]).
         1. If _module_.[[TopLevelCapability]] is not *undefined*, then
           1. Assert: _module_.[[DFSIndex]] is equal to _module_.[[DFSAncestorIndex]].
           1. Perform ! Call(_module_.[[TopLevelCapability]].[[Resolve]], *undefined*, &laquo;*undefined*&raquo;).
@@ -591,7 +591,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
     <emu-clause id="sec-AsyncModuleExecutionRejected" aoid="AsyncModuleExecutionRejected">
       <h1><ins>AsyncModuleExecutionRejected ( _module_, _error_ )</ins></h1>
       <emu-alg>
-        1. Assert: _module_.[[Status]] is `"evaluated"`.
+        1. Assert: _module_.[[Status]] is `"evaluating-async"` or `"evaluated"`.
         1. Assert: _module_.[[EvaluationError]] is *undefined*.
         1. Set _module_.[[Status]] to `"evaluated"`.
         1. Set _module_.[[EvaluationError]] to ThrowCompletion(_error_).

--- a/spec.html
+++ b/spec.html
@@ -514,12 +514,13 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
     <emu-clause id="sec-execute-async-module" aoid="ExecuteAsyncModule">
       <h1><ins>ExecuteAsyncModule ( _module_ )</ins></h1>
       <emu-alg>
-        1. Assert: _module_.[[Status]] is `"evaluating"` or `"evaluating-async"`.
+        1. Assert: _module_.[[Status]] is `"evaluating-async"`.
+        1. Assert: _module_.[[Async]] is *true*.
         1. Let _capability_ be ! NewPromiseCapability(%Promise%).
-        1. Let _stepsFulfilled_ be the steps of a CallCyclicModuleFulfilled function as specified below.
+        1. Let _stepsFulfilled_ be the steps of a CallAsyncModuleFulfilled function as specified below.
         1. Let _onFulfilled_ be CreateBuiltinFunction(_stepsFulfilled_, &laquo; [[Module]] &raquo;).
         1. Set _onFulfilled_.[[Module]] to _module_.
-        1. Let _stepsRejected_ be the steps of a CallCyclicModuleRejected function as specified below.
+        1. Let _stepsRejected_ be the steps of a CallAsyncModuleRejected function as specified below.
         1. Let _onRejected_ be CreateBuiltinFunction(_stepsRejected_, &laquo; [[Module]] &raquo;).
         1. Set _onRejected_.[[Module]] to _module_.
         1. Perform ! PerformPromiseThen(_capability_.[[Promise]], _onFulfilled_, _onRejected_).
@@ -527,7 +528,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. Return.
       </emu-alg>
 
-      <p>A CallCyclicModuleRejected function is an anonymous built-in function with a [[Module]] internal slot. When a CallCyclicModuleRejeced function is called that expects no arguments it performs the following steps:</p>
+      <p>A CallAsyncModuleRejected function is an anonymous built-in function with a [[Module]] internal slot. When a CallAsyncModuleRejeced function is called that expects no arguments it performs the following steps:</p>
       <emu-alg>
         1. Let _f_ be the active function object.
         1. Let _module_ be _f_.[[Module]].
@@ -535,7 +536,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. Return.
       </emu-alg>
 
-      <p>A CallCyclicModuleFulfilled function is an anonymous built-in function with a [[Module]] internal slot. When a CallCyclicModuleFulfilled function is called with argument _error_ it performs the following steps:</p>
+      <p>A CallAsyncModuleFulfilled function is an anonymous built-in function with a [[Module]] internal slot. When a CallAsyncModuleFulfilled function is called with argument _error_ it performs the following steps:</p>
       <emu-alg>
         1. Let _f_ be the active function object.
         1. Let _module_ be _f_.[[Module]].

--- a/spec.html
+++ b/spec.html
@@ -437,7 +437,9 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. <del>Return _result_.</del>
         1. <ins>Perform ! Call(_capability_.[[Reject]], *undefined*, &laquo;_result_.[[Value]]&raquo;).</ins>
       1. <ins>Otherwise,</ins>
-        1. Assert: _module_.[[Status]] is `"evaluated"`<ins> or `"evaluating-async"`</ins><del> and _module_.[[EvaluationError]] is *undefined*</del>.
+        1. Assert: _module_.[[Status]] is `"evaluated"`<ins> or `"evaluating-async"`</ins> and _module_.[[EvaluationError]] is *undefined*.
+        1. <ins>If _module_.[[Status]] is `"evaluated"`, then</ins>
+          1. <ins>Perform ! Call(_module_.[[TopLevelCapability]].[[Resolve]], *undefined*, &laquo;*undefined*&raquo;).</ins>
         1. Assert: _stack_ is empty.
       1. Return <del>*undefined*</del><ins>_capability_.[[Promise]]</ins>.
     </emu-alg>
@@ -483,8 +485,10 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
                 1. <ins>Append _module_ to _requiredModule_.[[AsyncParentModules]].</ins>
         1. <del>Perform ? _module_.ExecuteModule().</del>
         1. <ins>If _module_.[[PendingAsyncDependencies]] is 0, then</ins>
-          1. <ins>Perform ! ExecuteCyclicModule(_module_).</ins>
-          1. <ins>If _module_.[[EvaluationError]] is not *undefined*, return _module_.[[EvaluationError]].</ins>
+          1. <ins>If _module_.[[Async]] is *true*, then</ins>
+            1. <ins>Perform ! ExecuteAsyncModule(_module_).</ins>
+          1. <ins>Otherwise,</ins>
+            1. <ins>Perform ? _module_.ExecuteModule().</ins>
         1. Assert: _module_ occurs exactly once in _stack_.
         1. Assert: _module_.[[DFSAncestorIndex]] is less than or equal to _module_.[[DFSIndex]].
         1. If _module_.[[DFSAncestorIndex]] equals _module_.[[DFSIndex]], then
@@ -507,22 +511,22 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
       </emu-note>
     </emu-clause>
 
-    <emu-clause id="sec-execute-cyclic-module" aoid="ExecuteCyclicModule">
-      <h1><ins>ExecuteCyclicModule ( _module_ )</ins></h1>
+    <emu-clause id="sec-execute-async-module" aoid="ExecuteAsyncModule">
+      <h1><ins>ExecuteAsyncModule ( _module_ )</ins></h1>
       <emu-alg>
         1. Assert: _module_.[[Status]] is `"evaluating"` or `"evaluating-async"`.
         1. If _module_.[[Async]] is *false*, then:
           1. Let _result_ be _module_.ExecuteModule().
           1. If _result_ is a normal completion,
-            1. Perform ! CyclicModuleExecutionFulfilled(_module_).
+            1. Perform ! AsyncModuleExecutionFulfilled(_module_).
           1. Otherwise,
-            1. Perform ! CyclicModuleExecutionRejected(_module_, _result_.[[Value]]).
+            1. Perform ! AsyncModuleExecutionRejected(_module_, _result_.[[Value]]).
         1. Otherwise,
           1. Let _capability_ be ! NewPromiseCapability(%Promise%).
           1. Let _stepsFulfilled_ be the steps of a CallCyclicModuleFulfilled function as specified below.
           1. Let _onFulfilled_ be CreateBuiltinFunction(_stepsFulfilled_, &laquo; [[Module]] &raquo;).
           1. Set _onFulfilled_.[[Module]] to _module_.
-          1. Let _stepsFulfilled_ be the steps of a CallCyclicModuleRejected function as specified below.
+          1. Let _stepsRejected_ be the steps of a CallCyclicModuleRejected function as specified below.
           1. Let _onRejected_ be CreateBuiltinFunction(_stepsRejected_, &laquo; [[Module]] &raquo;).
           1. Set _onRejected_.[[Module]] to _module_.
           1. Perform ! PerformPromiseThen(_capability_.[[Promise]], _onFulfilled_, _onRejected_).
@@ -561,16 +565,12 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-cyclicmoduleexecutionfulfilled" aoid="CyclicModuleExecutionFulfilled">
-      <h1><ins>CyclicModuleExecutionFulfilled ( _module_ )</ins></h1>
+    <emu-clause id="sec-asyncmodulexecutionfulfilled" aoid="AsyncModuleExecutionFulfilled">
+      <h1><ins>AsyncModuleExecutionFulfilled ( _module_ )</ins></h1>
       <emu-alg>
-        1. Assert: _module_.[[Status]] is `"evaluating"`, `"evaluating-async"`, or `"evaluated"`.
+        1. Assert: _module_.[[Status]] is `"evaluated"`.
         1. Assert: _module_.[[EvaluationError]] is *undefined*.
-        1. If _module_.[[Status]] is `"evaluating"`, then
-          1. Assert: _module_.[[Async]] is *false*.
-          1. Assert: _module_.[[AsyncParentModules]] is an empty List.
-        1. If _module_.[[Status]] is `"evaluating-async"`, then
-          1. Set _module_.[[Status]] to `"evaluated"`.
+        1. Set _module_.[[Status]] to `"evaluated"`.
         1. For each Module _m_ of _module_.[[AsyncParentModules]], do
           1. If _module_.[[DFSIndex]] is not equal to _module_.[[DFSAncestorIndex]], then
             1. Assert: _m_.[[DFSAncestorIndex]] is equal to _module_.[[DFSAncestorIndex]].
@@ -579,7 +579,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
             1. Assert: _m_.[[Status]] is `"evaluating-async"`.
             1. Let _cycleRoot_ be ! GetCycleRoot(_m_).
             1. If _cycleRoot_.[[EvaluationError]] is not *undefined*, return *undefined*.
-            1. Perform ! ExecuteCyclicModule(_m_).
+            1. Perform ! ExecuteAsyncModule(_m_).
         1. If _module_.[[TopLevelCapability]] is not *undefined*, then
           1. Assert: _module_.[[DFSIndex]] is equal to _module_.[[DFSAncestorIndex]].
           1. Perform ! Call(_module_.[[TopLevelCapability]].[[Resolve]], *undefined*, &laquo;*undefined*&raquo;).
@@ -587,22 +587,18 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
       </emu-alg>
     </emu-clause>
 
-    <emu-clause id="sec-cyclicmoduleexecutionrejected" aoid="CyclicModuleExecutionRejected">
-      <h1><ins>CyclicModuleExecutionRejected ( _module_, _error_ )</ins></h1>
+    <emu-clause id="sec-AsyncModuleExecutionRejected" aoid="AsyncModuleExecutionRejected">
+      <h1><ins>AsyncModuleExecutionRejected ( _module_, _error_ )</ins></h1>
       <emu-alg>
-        1. Assert: _module_.[[Status]] is `"evaluating"` or `"evaluating-async"`.
+        1. Assert: _module_.[[Status]] is `"evaluated"`.
         1. Assert: _module_.[[EvaluationError]] is *undefined*.
-        1. If _module_.[[Status]] is `"evaluating"`, then
-          1. Assert: _module_.[[Async]] is *false*.
-          1. Assert: _module_.[[AsyncParentModules]] is an empty List.
-        1. If _module_.[[Status]] is `"evaluating-async"`, then
-          1. Set _module_.[[Status]] to `"evaluated"`.
+        1. Set _module_.[[Status]] to `"evaluated"`.
         1. Set _module_.[[EvaluationError]] to ThrowCompletion(_error_).
         1. For each Module _m_ of _module_.[[AsyncParentModules]], do
           1. If _module_.[[DFSIndex]] is not equal to _module_.[[DFSAncestorIndex]], then
             1. Assert: _m_.[[DFSAncestorIndex]] is equal to _module_.[[DFSAncestorIndex]].
           1. If _m_.[[Status]] is `"evaluating-async"`, then
-            1. Perform ! CyclicModuleExecutionRejected(_m_, _error_).
+            1. Perform ! AsyncModuleExecutionRejected(_m_, _error_).
         1. If _module_.[[TopLevelCapability]] is not *undefined*, then
           1. Assert: _module_.[[DFSIndex]] is equal to _module_.[[DFSAncestorIndex]].
           1. Perform ! Call(_module_.[[TopLevelCapability]].[[Reject]], *undefined*, &laquo;_error_&raquo;).
@@ -725,7 +721,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
 
     <p>Now consider a case where _A_ has an linking error; for example, it tries to import a binding from _C_ that does not exist. In that case, the above steps still occur, including the early return from the second call to InnerModuleLinking on _A_. However, once we unwind back to the original InnerModuleLinking on _A_, it fails during ModuleDeclarationEnvironmentSetup, namely right after _C_.ResolveExport(). The thrown *SyntaxError* exception propagates up to _A_.Link, which resets all modules that are currently on its _stack_ (these are always exactly the modules that are still `"linking"`). Hence both _A_ and _B_ become `"unlinked"`. Note that _C_ is left as `"linked"`.</p>
 
-    <p>Finally, consider a case where _A_ has an evaluation error; for example, its source code throws an exception. In that case, the evaluation-time analog of the above steps still occurs, including the early return from the second call to InnerModuleEvaluation on _A_. However, once we unwind back to the original InnerModuleEvaluation on _A_, it fails by assumption. The exception thrown propagates up to _A_.Evaluate(), which records the error in all modules that are currently on its _stack_ (i.e., the modules that are still `"evaluating"`) <ins>as well as via [[AsyncParentModules]], which form a chain for modules which contain or depend on top-level `await` through the whole dependency graph through the CyclicModuleExecutionRejected algorithm</ins>. Hence both _A_ and _B_ become `"evaluated"` and the exception is recorded in both _A_ and _B_'s [[EvaluationError]] fields, while _C_ is left as `"evaluated"` with no [[EvaluationError]].</p>
+    <p>Finally, consider a case where _A_ has an evaluation error; for example, its source code throws an exception. In that case, the evaluation-time analog of the above steps still occurs, including the early return from the second call to InnerModuleEvaluation on _A_. However, once we unwind back to the original InnerModuleEvaluation on _A_, it fails by assumption. The exception thrown propagates up to _A_.Evaluate(), which records the error in all modules that are currently on its _stack_ (i.e., the modules that are still `"evaluating"`) <ins>as well as via [[AsyncParentModules]], which form a chain for modules which contain or depend on top-level `await` through the whole dependency graph through the AsyncModuleExecutionRejected algorithm</ins>. Hence both _A_ and _B_ become `"evaluated"` and the exception is recorded in both _A_ and _B_'s [[EvaluationError]] fields, while _C_ is left as `"evaluated"` with no [[EvaluationError]].</p>
   </emu-clause>
 
   <emu-clause id="sec-toplevelmoduleevaluationjob" aoid="TopLevelModuleEvaluationJob">


### PR DESCRIPTION
This completes the editorial suggestion from https://github.com/tc39/proposal-top-level-await/pull/97 in inlining the sync execution handlers, which I wanted to just complete to demonstrate the mental model in place here.

I find this clarifies a lot of the logic quite a bit personally.

Update: since #114 was created, this is now a prerequisite PR for landing that.