### PR TITLE
Normative: Check for correct module state in CyclicModuleExecutionRejected()

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -580,7 +580,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
       <h1><ins>CyclicModuleExecutionRejected ( _module_, _error_ )</ins></h1>
       <emu-alg>
         1. Assert: _module_.[[EvaluationError]] is *undefined*.
-        1. If _module_.[[Status]] is `"instantiating"`, then
+        1. If _module_.[[Status]] is `"evaluating"`, then
           1. Assert: _module_.[[Async]] is *false*.
           1. Assert: _module_.[[AsyncParentModules]] is an empty List.
         1. If _module_.[[Status]] is `"evaluating-async"`, then


### PR DESCRIPTION
This algorithm used instantiating where evaluating was meant.
instantiating would never be the state. This patch fixes the error.

Ref #92.