### PR TITLE
Reject the promise in Evaluate().

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -433,11 +433,12 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
       1. If _result_ is an abrupt completion, then
         1. For each Cyclic Module Record _m_ in _stack_, do
           1. Assert: _m_.[[Status]] is `"evaluating"`.
+          1. <ins>Assert: _m_.[[AsyncParentModules]] is empty.</ins>
           1. Set _m_.[[Status]] to `"evaluated"`.
-          1. <del>Set _m_.[[EvaluationError]] to _result_.</del>
-          1. <ins>If _m_ is not the last element of _stack_, perform ! CyclicModuleExecutionRejected(_m_, _result_).</ins>
+          1. Set _m_.[[EvaluationError]] to _result_.
         1. Assert: _module_.[[Status]] is `"evaluated"` and _module_.[[EvaluationError]] is _result_.
         1. <del>Return _result_.</del>
+        1. <ins>Perform ! Call(_capability_.[[Reject]], *undefined*, &laquo;_result_.[[Value]]&raquo;).</ins>
       1. <ins>Otherwise,</ins>
         1. Assert: _module_.[[Status]] is `"evaluated"`<ins> or `"evaluating-async"`</ins><del> and _module_.[[EvaluationError]] is *undefined*</del>.
         1. Assert: _stack_ is empty.
@@ -582,7 +583,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
     <emu-clause id="sec-cyclicmoduleexecutionrejected" aoid="CyclicModuleExecutionRejected">
       <h1><ins>CyclicModuleExecutionRejected ( _module_, _error_ )</ins></h1>
       <emu-alg>
-        1. Assert: _module_.[[Status]] is `"evaluating"`, `"evaluating-async"` or `"evaluated"`.
+        1. Assert: _module_.[[Status]] is `"evaluating" or `"evaluating-async"`.
         1. Assert: _module_.[[EvaluationError]] is *undefined*.
         1. If _module_.[[Status]] is `"evaluating"`, then
           1. Assert: _module_.[[Async]] is *false*.


### PR DESCRIPTION
This avoids the complexity of ensuring it is safe to call
CyclicModuleExecutionRejected().

Fixes #102.