### PR TITLE
Normative: Fix cycle detection

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -479,7 +479,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
               1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
             1. <ins>Otherwise, set _requiredModule_ to GetCycleRoot(_requiredModule_).</ins>
             1. <ins>If _requiredModule_.[[EvaluationError]] is not *undefined*, return _module_.[[EvaluationError]].</ins>
-            1. <ins>If _cycle_ is *false*,</ins>
+            1. <ins>If _cycle_ is *false* and _requiredModule_.[[Status]] is not `"evaluated"`,</ins>
               1. <ins>If either _requiredModule_.[[Async]] is *true*, or _requiredModule_.[[PendingAsyncDependencies]] is not 0, then</ins>
                 1. <ins>Set _module_.[[PendingAsyncDependencies]] to _module_.[[PendingAsyncDependencies]] + 1.</ins>
                 1. <ins>Append _module_ to _requiredModule_.[[AsyncParentModules]].</ins>


### PR DESCRIPTION
Issue identified by Rob Palmer; fix by Guy Bedford.

This patch addresses cases like the following:

```
// Graph:  a -> b
// b uses TLA
import("b").then(() => import("a")   // a never completes
```

It fixes analysis of what's a cycle, which got confused in the
dynamic import case where it saw modules that are already loaded.