### PR TITLE
Editorial: Editor feedback

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -132,10 +132,6 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
     </table>
   </emu-table>
 
-  <emu-note type=editor>
-    <p>For all module types defined in this specification, it's statically determined (given the set of parsed modules and the graph connecting them) whether a module will have an [[EvaluationPromise]] which is not *undefined* after Evaluate() is called. A Promise is only present if the module or a dependency has the [[Async]] flag set. As more module types are added, the intention is that this would remain the case. However, concepts like "dependency" are not defined on Abstract Module Records.</p>
-  </emu-note>
-
   <emu-table id="table-37" caption="Abstract Methods of Module Records">
     <table>
       <tbody>

--- a/spec.html
+++ b/spec.html
@@ -46,6 +46,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
 <emu-clause id="sec-asyncblockstart" aoid="AsyncBlockStart">
   <h1><ins>AsyncBlockStart ( _promiseCapability_, _asyncBody_, _asyncContext_ )</ins></h1>
   <emu-alg>
+    1. Assert: _promiseCapability_ is a PromiseCapability Record.
     1. Let _runningContext_ be the running execution context.
     1. Set the code evaluation state of _asyncContext_ such that when evaluation is resumed for that execution context the following steps will be performed:
       1. Let _result_ be the result of evaluating _asyncBody_.
@@ -668,7 +669,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
           1. Resume the context that is now on the top of the execution context stack as the running execution context.
           1. Return Completion(_result_).
         1. <ins>Otherwise,</ins>
-          1. <ins>Assert: _capability_ was provided.</ins>
+          1. <ins>Assert: _capability_ is a PromiseCapability Record.</ins>
           1. <ins>Perform ! AsyncBlockStart(_capability_, _module_.[[ECMAScriptCode]], _moduleCxt_).</ins>
           1. <ins>Return.</ins>
       </emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -519,21 +519,31 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
             1. Perform ! CyclicModuleExecutionRejected(_module_, _result_.[[Value]]).
         1. Otherwise,
           1. Let _capability_ be ! NewPromiseCapability(%Promise%).
-          1. Let _stepsFulfilled_ be the following steps:
-            1. Let _F_ be the active function object.
-            1. Let _module_ be _F_.[[Module]].
-            1. Perform ! CyclicModuleExecutionFulfilled(_module_).
+          1. Let _stepsFulfilled_ be the steps of a CallCyclicModuleFulfilled function as specified below.
           1. Let _onFulfilled_ be CreateBuiltinFunction(_stepsFulfilled_, &laquo; [[Module]] &raquo;).
           1. Set _onFulfilled_.[[Module]] to _module_.
-          1. Let _stepsRejected_ be the following steps with argument _error_:
-            1. Let _F_ be the active function object.
-            1. Let _module_ be _F_.[[Module]].
-            1. Perform ! CyclicModuleExecutionRejected(_module_, _error_).
+          1. Let _stepsFulfilled_ be the steps of a CallCyclicModuleRejected function as specified below.
           1. Let _onRejected_ be CreateBuiltinFunction(_stepsRejected_, &laquo; [[Module]] &raquo;).
           1. Set _onRejected_.[[Module]] to _module_.
           1. Perform ! PerformPromiseThen(_capability_.[[Promise]], _onFulfilled_, _onRejected_).
           1. Perform ! _module_.ExecuteModule(_capability_).
           1. Return.
+      </emu-alg>
+
+      <p>A CallCyclicModuleRejected function is an anonymous built-in function with a [[Module]] internal slot. When a CallCyclicModuleRejeced function is called that expects no arguments it performs the following steps:</p>
+      <emu-alg>
+        1. Let _f_ be the active function object.
+        1. Let _module_ be _f_.[[Module]].
+        1. Perform ! CyclicModuleExecutionFulfilled(_module_).
+        1. Return.
+      </emu-alg>
+
+      <p>A CallCyclicModuleFulfilled function is an anonymous built-in function with a [[Module]] internal slot. When a CallCyclicModuleFulfilled function is called with argument _error_ it performs the following steps:</p>
+      <emu-alg>
+        1. Let _f_ be the active function object.
+        1. Let _module_ be _f_.[[Module]].
+        1. Perform ! CyclicModuleExecutionFulfilled(_module_, _error_).
+        1. Return.
       </emu-alg>
     </emu-clause>
 
@@ -731,12 +741,18 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
       1. Perform ? _m_.Link().
       1. Assert: All dependencies of _m_ have been transitively resolved and _m_ is ready for evaluation.
       1. <del>Return</del><ins>Let _promise_ be</ins> ? _m_.Evaluate().
-      1. <ins>Let _stepsRejected_ be the following steps with argument _reason_</ins>
-        1. <ins>Perform HostReportErrors(&laquo; _reason_ &raquo;).</ins>
+      1. <ins>Let _stepsRejected_ be the steps of a ReportRejectedError function as specified below.</ins>
       1. <ins>Let _onRejected_ be CreateBuiltinFunction(_stepsRejected_).</ins>
       1. <ins>Perform ! PerformPromiseThen(_promise_, *undefined*, _onRejected_).</ins>
       1. <ins>Return.</ins>
     </emu-alg>
+
+    <p><ins>A ReportRejectedError function is an anonymous built-in function. When a ReportRejectedError function is called with argument _reason_ it performs the following steps:</ins></p>
+    <emu-alg>
+      1. <ins>Perform HostReportErrors(&laquo; _reason_ &raquo;).</ins>
+      1. <ins>Return.</ins>
+    </emu-alg>
+
     <emu-note>
       <p>An implementation may parse a _sourceText_ as a |Module|, analyse it for Early Error conditions, and link it prior to the execution of the TopLevelModuleEvaluationJob for that _sourceText_. An implementation may also resolve, pre-parse and pre-analyse, and pre-link module dependencies of _sourceText_. However, the reporting of any errors detected by these actions must be deferred until the TopLevelModuleEvaluationJob is actually executed.</p>
     </emu-note>

--- a/spec.html
+++ b/spec.html
@@ -103,7 +103,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
           Lexical Environment | *undefined*
         </td>
         <td>
-          The Lexical Environment containing the top level bindings for this module. This field is set when the module is instantiated.
+          The Lexical Environment containing the top level bindings for this module. This field is set when the module is linked.
         </td>
       </tr>
       <tr>
@@ -166,7 +166,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
       </tr>
       <tr>
         <td>
-          Instantiate()
+          Link()
         </td>
         <td>
           <p>Prepare the module for evaluation by transitively resolving all module dependencies and creating a module Environment Record.</p>
@@ -178,7 +178,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         </td>
         <td>
           <p><ins>Returns a promise for the evaluation of this module and its dependencies, resolving on successful evaluation or if it has already been evaluated, and rejecting for an evaluation error or</ins><del>If this module has already been evaluated successfully, return *undefined*; </del>if it has already been evaluated unsuccessfully<del>, throw the exception that was produced. Otherwise, Transitively evaluate all module dependencies of this module and then evaluate this module.</del></p>
-          <p>Instantiate must have completed successfully prior to invoking this method.</p>
+          <p>Link must have completed successfully prior to invoking this method.</p>
         </td>
       </tr>
       </tbody>
@@ -213,7 +213,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
             String
           </td>
           <td>
-            Initially `"uninstantiated"`. Transitions to `"instantiating"`, `"instantiated"`, `"evaluating"`, <ins>`"evaluating-async`" (for async modules and parents of async modules)</ins>, `"evaluated"` (in that order) as the module progresses throughout its lifecycle.
+            Initially `"unlinked"`. Transitions to `"linking"`, `"linked"`, `"evaluating"`, <ins>`"evaluating-async`" (for async modules and parents of async modules)</ins>, `"evaluated"` (in that order) as the module progresses throughout its lifecycle.
           </td>
         </tr>
         <tr>
@@ -235,8 +235,8 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
             Integer | *undefined*
           </td>
           <td>
-            Auxiliary field used during Instantiate and Evaluate only.
-            If [[Status]] is `"instantiating"` or `"evaluating"`, this nonnegative number records the point at which the module was first visited during the ongoing depth-first traversal of the dependency graph.
+            Auxiliary field used during Link and Evaluate only.
+            If [[Status]] is `"linking"` or `"evaluating"`, this nonnegative number records the point at which the module was first visited during the ongoing depth-first traversal of the dependency graph.
           </td>
         </tr>
         <tr>
@@ -247,7 +247,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
             Integer | *undefined*
           </td>
           <td>
-            Auxiliary field used during Instantiate and Evaluate only. If [[Status]] is `"instantiating"` or `"evaluating"`, this is either the module's own [[DFSIndex]] or that of an "earlier" module in the same strongly connected component.
+            Auxiliary field used during Link and Evaluate only. If [[Status]] is `"linking"` or `"evaluating"`, this is either the module's own [[DFSIndex]] or that of an "earlier" module in the same strongly connected component.
           </td>
         </tr>
         <tr>
@@ -340,59 +340,59 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
       </table>
     </emu-table>
 
-  <emu-clause id="sec-moduledeclarationinstantiation">
-    <h1>Instantiate ( ) Concrete Method</h1>
+  <emu-clause id="sec-moduledeclarationlinking" oldids="sec-moduledeclarationinstantiation">
+    <h1>Link ( ) Concrete Method</h1>
 
-    <p>The Instantiate concrete method of a Cyclic Module Record implements the corresponding Module Record abstract method.</p>
-    <p>On success, Instantiate transitions this module's [[Status]] from `"uninstantiated"` to `"instantiated"`. On failure, an exception is thrown and this module's [[Status]] remains `"uninstantiated"`.</p>
+    <p>The Link concrete method of a Cyclic Module Record implements the corresponding Module Record abstract method.</p>
+    <p>On success, Link transitions this module's [[Status]] from `"unlinked"` to `"linked"`. On failure, an exception is thrown and this module's [[Status]] remains `"unlinked"`.</p>
 
-    <p>This abstract method performs the following steps (most of the work is done by the auxiliary function InnerModuleInstantiation):</p>
+    <p>This abstract method performs the following steps (most of the work is done by the auxiliary function InnerModuleLinking):</p>
 
     <emu-alg>
       1. Let _module_ be this Cyclic Module Record.
-      1. Assert: _module_.[[Status]] is not `"instantiating"` or `"evaluating"`.
+      1. Assert: _module_.[[Status]] is not `"linking"` or `"evaluating"`.
       1. Let _stack_ be a new empty List.
-      1. Let _result_ be InnerModuleInstantiation(_module_, _stack_, 0).
+      1. Let _result_ be InnerModuleLinking(_module_, _stack_, 0).
       1. If _result_ is an abrupt completion, then
         1. For each Cyclic Module Record _m_ in _stack_, do
-          1. Assert: _m_.[[Status]] is `"instantiating"`.
-          1. Set _m_.[[Status]] to `"uninstantiated"`.
+          1. Assert: _m_.[[Status]] is `"linking"`.
+          1. Set _m_.[[Status]] to `"unlinked"`.
           1. Set _m_.[[Environment]] to *undefined*.
           1. Set _m_.[[DFSIndex]] to *undefined*.
           1. Set _m_.[[DFSAncestorIndex]] to *undefined*.
-        1. Assert: _module_.[[Status]] is `"uninstantiated"`.
+        1. Assert: _module_.[[Status]] is `"unlinked"`.
         1. Return _result_.
-      1. Assert: _module_.[[Status]] is `"instantiated"`<ins>, `"evaluating-async"`</ins> or `"evaluated"`.
+      1. Assert: _module_.[[Status]] is `"linked"`<ins>, `"evaluating-async"`</ins> or `"evaluated"`.
       1. Assert: _stack_ is empty.
       1. Return *undefined*.
     </emu-alg>
 
-    <emu-clause id="sec-innermoduleinstantiation" aoid="InnerModuleInstantiation">
-      <h1>InnerModuleInstantiation ( _module_, _stack_, _index_ )</h1>
+    <emu-clause id="sec-InnerModuleLinking" oldids="sec-innermoduleinstantiation" aoid="InnerModuleLinking">
+      <h1>InnerModuleLinking ( _module_, _stack_, _index_ )</h1>
 
-      <p>The InnerModuleInstantiation abstract operation is used by Instantiate to perform the actual instantiation process for the Cyclic Module Record _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as a module's [[DFSIndex]] and [[DFSAncestorIndex]] fields, keep track of the depth-first search (DFS) traversal. In particular, [[DFSAncestorIndex]] is used to discover strongly connected components (SCCs), such that all modules in an SCC transition to `"instantiated"` together.</p>
+      <p>The InnerModuleLinking abstract operation is used by Link to perform the actual linking process for the Cyclic Module Record _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as a module's [[DFSIndex]] and [[DFSAncestorIndex]] fields, keep track of the depth-first search (DFS) traversal. In particular, [[DFSAncestorIndex]] is used to discover strongly connected components (SCCs), such that all modules in an SCC transition to `"linked"` together.</p>
 
       <p>This abstract operation performs the following steps:</p>
 
       <emu-alg>
         1. If _module_ is not a Cyclic Module Record, then
-          1. Perform ? _module_.Instantiate().
+          1. Perform ? _module_.Link().
           1. Return _index_.
-        1. If _module_.[[Status]] is `"instantiating"`, `"instantiated"`, <ins>`"evaluating-async"`,</ins> or `"evaluated"`, then
+        1. If _module_.[[Status]] is `"linking"`, `"linked"`, <ins>`"evaluating-async"`,</ins> or `"evaluated"`, then
           1. Return _index_.
-        1. Assert: _module_.[[Status]] is `"uninstantiated"`.
-        1. Set _module_.[[Status]] to `"instantiating"`.
+        1. Assert: _module_.[[Status]] is `"unlinked"`.
+        1. Set _module_.[[Status]] to `"linking"`.
         1. Set _module_.[[DFSIndex]] to _index_.
         1. Set _module_.[[DFSAncestorIndex]] to _index_.
         1. Increase _index_ by 1.
         1. Append _module_ to _stack_.
         1. For each String _required_ that is an element of _module_.[[RequestedModules]], do
           1. Let _requiredModule_ be ? HostResolveImportedModule(_module_, _required_).
-          1. Set _index_ to ? InnerModuleInstantiation(_requiredModule_, _stack_, _index_).
+          1. Set _index_ to ? InnerModuleLinking(_requiredModule_, _stack_, _index_).
           1. If _requiredModule_ is a Cyclic Module Record, then
-            1. Assert: _requiredModule_.[[Status]] is either `"instantiating"`, `"instantiated"`, <ins>`"evaluating-async"`,</ins> or `"evaluated"`.
-            1. Assert: _requiredModule_.[[Status]] is `"instantiating"` if and only if _requiredModule_ is in _stack_.
-            1. If _requiredModule_.[[Status]] is `"instantiating"`, then
+            1. Assert: _requiredModule_.[[Status]] is either `"linking"`, `"linked"`, <ins>`"evaluating-async"`,</ins> or `"evaluated"`.
+            1. Assert: _requiredModule_.[[Status]] is `"linking"` if and only if _requiredModule_ is in _stack_.
+            1. If _requiredModule_.[[Status]] is `"linking"`, then
               1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
         1. Perform ? _module_.InitializeEnvironment().
         1. Assert: _module_ occurs exactly once in _stack_.
@@ -403,7 +403,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
             1. Let _requiredModule_ be the last element in _stack_.
             1. Remove the last element of _stack_.
             1. Assert: _requiredModule_ is a Cyclic Module Record.
-            1. Set _requiredModule_.[[Status]] to `"instantiated"`.
+            1. Set _requiredModule_.[[Status]] to `"linked"`.
             1. If _requiredModule_ and _module_ are the same Module Record, set _done_ to *true*.
         1. Return _index_.
       </emu-alg>
@@ -414,7 +414,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
     <h1>Evaluate ( ) Concrete Method</h1>
 
     <p>The Evaluate concrete method of a Cyclic Module Record implements the corresponding Module Record abstract method.</p>
-    <p>Evaluate transitions this module's [[Status]] from `"instantiated"` to `"evaluated"`<ins> or `"evaluating-async"`</ins>.</p>
+    <p>Evaluate transitions this module's [[Status]] from `"linked"` to `"evaluated"`<ins> or `"evaluating-async"`</ins>.</p>
 
     <p>If execution results in a <ins>synchronous</ins> exception, that exception is recorded in the [[EvaluationError]] field and rethrown by future invocations of Evaluate.</p>
 
@@ -422,7 +422,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
 
     <emu-alg>
       1. Let _module_ be this Cyclic Module Record.
-      1. Assert: _module_.[[Status]] is `"instantiated"`<ins>, `"evaluating-async"`</ins> or `"evaluated"`.
+      1. Assert: _module_.[[Status]] is `"linked"`<ins>, `"evaluating-async"`</ins> or `"evaluated"`.
       1. <ins>If _module_.[[Status]] is `"evaluated"` or `"evaluating-async"`, set _module_ to GetCycleRoot(_module_).</ins>
       1. <ins>If _module_.[[TopLevelCapability]] is not *undefined*, then</ins>
         1. <ins>Return _module_.[[TopLevelCapability]].</ins>
@@ -448,7 +448,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
     <emu-clause id="sec-innermoduleevaluation" aoid="InnerModuleEvaluation">
       <h1>InnerModuleEvaluation( _module_, _stack_, _index_ )</h1>
 
-      <p>The InnerModuleEvaluation abstract operation is used by Evaluate to perform the actual evaluation process for the Cyclic Module Record _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSIndex]] and [[DFSAncestoreIndex]] fields, are used the same way as in InnerModuleInstantiation.</p>
+      <p>The InnerModuleEvaluation abstract operation is used by Evaluate to perform the actual evaluation process for the Cyclic Module Record _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSIndex]] and [[DFSAncestoreIndex]] fields, are used the same way as in InnerModuleLinking.</p>
 
       <p>This abstract operation performs the following steps:</p>
 
@@ -460,7 +460,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
           1. If _module_.[[EvaluationError]] is *undefined*, return _index_.
           1. Otherwise return _module_.[[EvaluationError]].
         1. If _module_.[[Status]] is `"evaluating"`, return _index_.
-        1. Assert: _module_.[[Status]] is `"instantiated"`.
+        1. Assert: _module_.[[Status]] is `"linked"`.
         1. Set _module_.[[Status]] to `"evaluating"`.
         1. Set _module_.[[DFSIndex]] to _index_.
         1. Set _module_.[[DFSAncestorIndex]] to _index_.
@@ -470,7 +470,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. Append _module_ to _stack_.
         1. For each String _required_ that is an element of _module_.[[RequestedModules]], do
           1. Let _requiredModule_ be ! HostResolveImportedModule(_module_, _required_).
-          1. NOTE: Instantiate must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
+          1. NOTE: Link must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
           1. <ins>Let _cycle_ be *true* if _requiredModule_.[[Status]] is `"evaluating"`, and *false* otherwise.</ins>
           1. Set _index_ to ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_).
           1. If _requiredModule_ is a Cyclic Module Record, then
@@ -638,7 +638,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. Else,
           1. Append _ee_ to _indirectExportEntries_.
       1. <ins>Let _async_ be _body_ Contains |AwaitExpression|.</ins>
-      1. Return Source Text Module Record { [[Realm]]: _realm_, [[Environment]]: *undefined*, [[Namespace]]: *undefined*, <ins>[[Async]]: _async_, [[TopLevelCapability]]: *undefined*, [[AsyncParentModules]]: *undefined*, [[PendingAsyncDependencies]]: *undefined*, </ins>[[Status]]: `"uninstantiated"`, [[EvaluationError]]: *undefined*, [[HostDefined]]: _hostDefined_, [[ECMAScriptCode]]: _body_, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[DFSIndex]]: *undefined*, [[DFSAncestorIndex]]: *undefined* }.
+      1. Return Source Text Module Record { [[Realm]]: _realm_, [[Environment]]: *undefined*, [[Namespace]]: *undefined*, <ins>[[Async]]: _async_, [[TopLevelCapability]]: *undefined*, [[AsyncParentModules]]: *undefined*, [[PendingAsyncDependencies]]: *undefined*, </ins>[[Status]]: `"unlinked"`, [[EvaluationError]]: *undefined*, [[HostDefined]]: _hostDefined_, [[ECMAScriptCode]]: _body_, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[DFSIndex]]: *undefined*, [[DFSAncestorIndex]]: *undefined* }.
     </emu-alg>
     <emu-note>
       <p>An implementation may parse module source text and analyse it for Early Error conditions prior to the evaluation of ParseModule for that module source text. However, the reporting of any errors must be deferred until the point where this specification actually performs ParseModule upon that source text.</p>
@@ -660,7 +660,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. Assert: _module_.[[Realm]] is not *undefined*.
         1. Set the Realm of _moduleCxt_ to _module_.[[Realm]].
         1. Set the ScriptOrModule of _moduleCxt_ to _module_.
-        1. Assert: _module_ has been linked and declarations in its module environment have been instantiated.
+        1. Assert: _module_ has been linked and declarations in its module environment have been linked.
         1. Set the VariableEnvironment of _moduleCxt_ to _module_.[[Environment]].
         1. Set the LexicalEnvironment of _moduleCxt_ to _module_.[[Environment]].
         1. Suspend the currently running execution context.
@@ -682,7 +682,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
   <emu-clause id="sec-example-source-text-module-record-graphs">
     <h1>Example Source Text Module Record Graphs</h1>
 
-    <p>This non-normative section gives a series of examples of the instantiation and evaluation of a few common module graphs, with a specific focus on how errors can occur.</p>
+    <p>This non-normative section gives a series of examples of the linking and evaluation of a few common module graphs, with a specific focus on how errors can occur.</p>
 
     <p>First consider the following simple module graph:</p>
 
@@ -690,13 +690,13 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
       <img alt="A module graph in which module A depends on module B" width="121" height="211" src="img/module-graph-simple.svg">
     </emu-figure>
 
-    <p>Let's first assume that there are no error conditions. When a host first calls _A_.Instantiate(), this will complete successfully by assumption, and recursively instantiate modules _B_ and _C_ as well, such that _A_.[[Status]] = _B_.[[Status]] = _C_.[[Status]] = `"instantiated"`. This preparatory step can be performed at any time. Later, when the host is ready to incur any possible side effects of the modules, it can call _A_.Evaluate(), which will complete successfully<ins>, returning a Promise resolving to *undefined*</ins> (again by assumption), recursively having evaluated first _C_ and then _B_. Each module's [[Status]] at this point will be `"evaluated`".</p>
+    <p>Let's first assume that there are no error conditions. When a host first calls _A_.Link(), this will complete successfully by assumption, and recursively instantiate modules _B_ and _C_ as well, such that _A_.[[Status]] = _B_.[[Status]] = _C_.[[Status]] = `"linked"`. This preparatory step can be performed at any time. Later, when the host is ready to incur any possible side effects of the modules, it can call _A_.Evaluate(), which will complete successfully<ins>, returning a Promise resolving to *undefined*</ins> (again by assumption), recursively having evaluated first _C_ and then _B_. Each module's [[Status]] at this point will be `"evaluated`".</p>
 
-    <p>Consider then cases involving instantiation errors. If InnerModuleInstantiation of _C_ succeeds but, thereafter, fails for _B_, for example because it imports something that _C_ does not provide, then the original _A_.Instantiate() will fail, and both _A_ and _B_'s [[Status]] remain `"uninstantiated"`. _C_'s [[Status]] has become `"instantiated"`, though.</p>
+    <p>Consider then cases involving linking errors. If InnerModuleLinking of _C_ succeeds but, thereafter, fails for _B_, for example because it imports something that _C_ does not provide, then the original _A_.Link() will fail, and both _A_ and _B_'s [[Status]] remain `"unlinked"`. _C_'s [[Status]] has become `"linked"`, though.</p>
 
     <p>Finally, consider a case involving evaluation errors. If InnerModuleEvaluation of _C_ succeeds but, thereafter, fails for _B_, for example because _B_ contains code that throws an exception, then the original _A_.Evaluate() will fail<ins>, returning a rejected Promise</ins>. The resulting exception will be recorded in both _A_ and _B_'s [[EvaluationError]] fields, and their [[Status]] will become `"evaluated"`. _C_ will also become `"evaluated"` but, in contrast to _A_ and _B_, will remain without an [[EvaluationError]], as it successfully completed evaluation. Storing the exception ensures that any time a host tries to reuse _A_ or _B_ by calling their Evaluate() method, it will encounter the same exception. (Hosts are not required to reuse Source Text Module Records; similarly, hosts are not required to expose the exception objects thrown by these  methods. However, the specification enables such uses.)</p>
 
-    <p>The difference here between instantiation and evaluation errors is due to how evaluation must be only performed once, as it can cause side effects; it is thus important to remember whether evaluation has already been performed, even if unsuccessfully. (In the error case, it makes sense to also remember the exception because otherwise subsequent Evaluate() calls would have to synthesize a new one.) Instantiation, on the other hand, is side-effect-free, and thus even if it fails, it can be retried at a later time with no issues.</p>
+    <p>The difference here between linking and evaluation errors is due to how evaluation must be only performed once, as it can cause side effects; it is thus important to remember whether evaluation has already been performed, even if unsuccessfully. (In the error case, it makes sense to also remember the exception because otherwise subsequent Evaluate() calls would have to synthesize a new one.) Linking, on the other hand, is side-effect-free, and thus even if it fails, it can be retried at a later time with no issues.</p>
 
     <p>Now consider a different type of error condition:</p>
 
@@ -704,7 +704,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
       <img alt="A module graph in which module A depends on a missing (unresolvable) module, represented by ???" width="121" height="121" src="img/module-graph-missing.svg">
     </emu-figure>
 
-    <p>In this scenario, module _A_ declares a dependency on some other module, but no Module Record exists for that module, i.e. HostResolveImportedModule throws an exception when asked for it. This could occur for a variety of reasons, such as the corresponding resource not existing, or the resource existing but ParseModule throwing an exception when trying to parse the resulting source text. Hosts can choose to expose the cause of failure via the exception they throw from HostResolveImportedModule. In any case, this exception causes an instantiation failure, which as before results in _A_'s [[Status]] remaining `"uninstantiated"`.</p>
+    <p>In this scenario, module _A_ declares a dependency on some other module, but no Module Record exists for that module, i.e. HostResolveImportedModule throws an exception when asked for it. This could occur for a variety of reasons, such as the corresponding resource not existing, or the resource existing but ParseModule throwing an exception when trying to parse the resulting source text. Hosts can choose to expose the cause of failure via the exception they throw from HostResolveImportedModule. In any case, this exception causes an linking failure, which as before results in _A_'s [[Status]] remaining `"unlinked"`.</p>
 
     <p>Lastly, consider a module graph with a cycle:</p>
 
@@ -712,11 +712,11 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
       <img alt="A module graph in which module A depends on module B and C, but module B also depends on module A" width="181" height="121" src="img/module-graph-cycle.svg">
     </emu-figure>
 
-    <p>Here we assume that the entry point is module _A_, so that the host proceeds by calling _A_.Instantiate(), which performs InnerModuleInstantiation on _A_. This in turn calls InnerModuleInstantiation on _B_. Because of the cycle, this again triggers InnerModuleInstantiation on _A_, but at this point it is a no-op since _A_.[[Status]] is already `"instantiating"`. _B_.[[Status]] itself remains `"instantiating"` when control gets back to _A_ and InnerModuleInstantiation is triggered on _C_. After this returns with _C_.[[Status]] being `"instantiated"` , both _A_ and _B_ transition from `"instantiating"` to `"instantiated"` together; this is by design, since they form a strongly connected component.</p>
+    <p>Here we assume that the entry point is module _A_, so that the host proceeds by calling _A_.Link(), which performs InnerModuleLinking on _A_. This in turn calls InnerModuleLinking on _B_. Because of the cycle, this again triggers InnerModuleLinking on _A_, but at this point it is a no-op since _A_.[[Status]] is already `"linking"`. _B_.[[Status]] itself remains `"linking"` when control gets back to _A_ and InnerModuleLinking is triggered on _C_. After this returns with _C_.[[Status]] being `"linked"` , both _A_ and _B_ transition from `"linking"` to `"linked"` together; this is by design, since they form a strongly connected component.</p>
 
     <p>An analogous story occurs for the evaluation phase of a cyclic module graph, in the success case.</p>
 
-    <p>Now consider a case where _A_ has an instantiation error; for example, it tries to import a binding from _C_ that does not exist. In that case, the above steps still occur, including the early return from the second call to InnerModuleInstantiation on _A_. However, once we unwind back to the original InnerModuleInstantiation on _A_, it fails during ModuleDeclarationEnvironmentSetup, namely right after _C_.ResolveExport(). The thrown *SyntaxError* exception propagates up to _A_.Instantiate, which resets all modules that are currently on its _stack_ (these are always exactly the modules that are still `"instantiating"`). Hence both _A_ and _B_ become `"uninstantiated"`. Note that _C_ is left as `"instantiated"`.</p>
+    <p>Now consider a case where _A_ has an linking error; for example, it tries to import a binding from _C_ that does not exist. In that case, the above steps still occur, including the early return from the second call to InnerModuleLinking on _A_. However, once we unwind back to the original InnerModuleLinking on _A_, it fails during ModuleDeclarationEnvironmentSetup, namely right after _C_.ResolveExport(). The thrown *SyntaxError* exception propagates up to _A_.Link, which resets all modules that are currently on its _stack_ (these are always exactly the modules that are still `"linking"`). Hence both _A_ and _B_ become `"unlinked"`. Note that _C_ is left as `"linked"`.</p>
 
     <p>Finally, consider a case where _A_ has an evaluation error; for example, its source code throws an exception. In that case, the evaluation-time analog of the above steps still occurs, including the early return from the second call to InnerModuleEvaluation on _A_. However, once we unwind back to the original InnerModuleEvaluation on _A_, it fails by assumption. The exception thrown propagates up to _A_.Evaluate(), which records the error in all modules that are currently on its _stack_ (i.e., the modules that are still `"evaluating"`) <ins>as well as via [[AsyncParentModules]], which form a chain for modules which contain or depend on top-level `await` through the whole dependency graph through the CyclicModuleExecutionRejected algorithm</ins>. Hence both _A_ and _B_ become `"evaluated"` and the exception is recorded in both _A_ and _B_'s [[EvaluationError]] fields, while _C_ is left as `"evaluated"` with no [[EvaluationError]].</p>
   </emu-clause>
@@ -731,7 +731,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
       1. If _m_ is a List of errors, then
         1. Perform HostReportErrors(_m_).
         1. Return NormalCompletion(*undefined*).
-      1. Perform ? _m_.Instantiate().
+      1. Perform ? _m_.Link().
       1. Assert: All dependencies of _m_ have been transitively resolved and _m_ is ready for evaluation.
       1. <del>Return</del><ins>Let _promise_ be</ins> ? _m_.Evaluate().
       1. <ins>Let _stepsRejected_ be the following steps with argument _reason_</ins>
@@ -741,7 +741,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
       1. <ins>Return.</ins>
     </emu-alg>
     <emu-note>
-      <p>An implementation may parse a _sourceText_ as a |Module|, analyse it for Early Error conditions, and instantiate it prior to the execution of the TopLevelModuleEvaluationJob for that _sourceText_. An implementation may also resolve, pre-parse and pre-analyse, and pre-instantiate module dependencies of _sourceText_. However, the reporting of any errors detected by these actions must be deferred until the TopLevelModuleEvaluationJob is actually executed.</p>
+      <p>An implementation may parse a _sourceText_ as a |Module|, analyse it for Early Error conditions, and link it prior to the execution of the TopLevelModuleEvaluationJob for that _sourceText_. An implementation may also resolve, pre-parse and pre-analyse, and pre-link module dependencies of _sourceText_. However, the reporting of any errors detected by these actions must be deferred until the TopLevelModuleEvaluationJob is actually executed.</p>
     </emu-note>
   </emu-clause>
 


### PR DESCRIPTION
This includes the feedback from @ljharb from https://github.com/tc39/proposal-top-level-await/issues/77#issuecomment-498940971, including:

1. "rebasing" to the renaming of `instantiate` to `link`.
2. Remove the now-unnecessary editors note from a previous iteration
3. Include promise capability assertions.
4. Separating out the _steps_ promise resolutions into their own abstract functions referenced.

Will continue discussion on some of the other points continuing in the thread on #77.