### PR TITLE
fix assertion in Evaluate()

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -440,7 +440,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
 
     <emu-alg>
       1. Let _module_ be this Cyclic Module Record.
-      1. Assert: _module_.[[Status]] is `"linked"` or `"evaluated"`.
+      1. Assert: _module_.[[Status]] is `"linked"`, `"evaluating"`, or `"evaluated"`.
       1. <ins>If _module_.[[Status]] is `"evaluated"`, set _module_ to GetCycleRoot(_module_).</ins>
       1. <ins>If _module_.[[TopLevelCapability]] is not *undefined*, then</ins>
         1. <ins>Return _module_.[[TopLevelCapability]].[[Promise]].</ins>


### PR DESCRIPTION
The status can be "evaluating" if an implementation has a synchronous implementation of HostImportModuleDynamically. In the current spec, there's no real way to fix this, because calling Evaluate() multiple times isn't safe. However in in this proposal, the early return with TopLevelCapability fixes this.

example that causes this assertion to fail:
```
HostImportModuleDynamically(referencingScriptOrModule, specifier, promiseCapability)
  1. Let completion be HostResolveImportedModule(referencingScriptOrModule, specifier).
  2. If completion is not an abrupt completion, let module be completion.[[Value]].
  3. If completion is not an abrupt completion, set completion to module.Link().
  4. If completion is not an abrupt completion, set completion to module.Evaluate().
  5. Perform FinishDynamicImport(referencingScriptOrModule, specifier, promiseCapability, completion).
```