### PR TITLE
Fix GetAsyncCycleRoot and AsyncModuleExecutionFulfilled cycle assertions

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -570,7 +570,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. Repeat, while _module_.[[DFSIndex]] is greater than _module_.[[DFSAncestorIndex]],
           1. Assert: _module_.[[AsyncParentModules]] is a non-empty List.
           1. Let _nextCycleModule_ be the first element of _module_.[[AsyncParentModules]].
-          1. Assert: _nextCycleModule_.[[DFSAncestorIndex]] is equal to _module_.[[DFSAncestorIndex]].
+          1. Assert: _nextCycleModule_.[[DFSAncestorIndex]] is less than or equal to _module_.[[DFSAncestorIndex]].
           1. Set _module_ to _nextCycleModule_.
         1. Assert: _module_.[[DFSIndex]] is equal to _module_.[[DFSAncestorIndex]].
         1. Return _module_.

--- a/spec.html
+++ b/spec.html
@@ -588,7 +588,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
         1. Set _module_.[[AsyncEvaluating]] to *false*.
         1. For each Module _m_ of _module_.[[AsyncParentModules]], do
           1. If _module_.[[DFSIndex]] is not equal to _module_.[[DFSAncestorIndex]], then
-            1. Assert: _m_.[[DFSAncestorIndex]] is equal to _module_.[[DFSAncestorIndex]].
+            1. Assert: _m_.[[DFSAncestorIndex]] is less than or equal to _module_.[[DFSAncestorIndex]].
           1. Decrement _m_.[[PendingAsyncDependencies]] by 1.
           1. If _m_.[[PendingAsyncDependencies]] is 0 and _m_.[[EvaluationError]] is *undefined*, then
             1. Assert: _m_.[[AsyncEvaluating]] is *true*.


### PR DESCRIPTION
This fixes the assertion failures in #111 for multiple connected cycles, ensuring the root returned is the root of the entire connected component.

We continue following the parent chain until the DFSAncestorIndex is equal to the DFSIndex, allowing transitions through intermediate DFSAncestorIndex values as in the example there.