### PR TITLE
Normative: Account for for-await in [[Async]]

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -664,7 +664,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
           1. Append _ee_ to _starExportEntries_.
         1. Else,
           1. Append _ee_ to _indirectExportEntries_.
-      1. <ins>Let _async_ be _body_ Contains |AwaitExpression|.</ins>
+      1. <ins>Let _async_ be _body_ Contains `await`.</ins>
       1. Return Source Text Module Record { [[Realm]]: _realm_, [[Environment]]: *undefined*, [[Namespace]]: *undefined*, <ins>[[Async]]: _async_, [[AsyncEvaluating]]: *false*, [[TopLevelCapability]]: *undefined*, [[AsyncParentModules]]: *undefined*, [[PendingAsyncDependencies]]: *undefined*, </ins>[[Status]]: `"unlinked"`, [[EvaluationError]]: *undefined*, [[HostDefined]]: _hostDefined_, [[ECMAScriptCode]]: _body_, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[DFSIndex]]: *undefined*, [[DFSAncestorIndex]]: *undefined* }.
     </emu-alg>
     <emu-note>


### PR DESCRIPTION
Closes #132

Note that `await` in module contexts is always a keyword, so the "Contains `await`" static semantics in this patch will never match an `await` identifier.