### PR TITLE
Editorial: Reword Evaluate's exception paragraph

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -434,7 +434,7 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
     <p>The Evaluate concrete method of a Cyclic Module Record implements the corresponding Module Record abstract method.</p>
     <p>Evaluate transitions this module's [[Status]] from `"linked"` to `"evaluated"`.</p>
 
-    <p><del>If execution results in a synchronous exception, that exception is recorded in the [[EvaluationError]] field and rethrown by future invocations of Evaluate.</del></p>
+    <p><del>If execution results in a exception, that exception is recorded in the [[EvaluationError]] field and rethrown by future invocations of Evaluate.</del></p>
 
     <p><ins>The Promise returned by Evaluate is allocated by the first invocation of Evaluate, and its capability is stored in the [[TopLevelCapability]] field. If execution results in an exception, the Promise is rejected. Future invocations of Evaluate return the same Promise.</ins></p>
 

--- a/spec.html
+++ b/spec.html
@@ -434,7 +434,9 @@ contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
     <p>The Evaluate concrete method of a Cyclic Module Record implements the corresponding Module Record abstract method.</p>
     <p>Evaluate transitions this module's [[Status]] from `"linked"` to `"evaluated"`.</p>
 
-    <p>If execution results in a <ins>synchronous</ins> exception, that exception is recorded in the [[EvaluationError]] field and rethrown by future invocations of Evaluate.</p>
+    <p><del>If execution results in a synchronous exception, that exception is recorded in the [[EvaluationError]] field and rethrown by future invocations of Evaluate.</del></p>
+
+    <p><ins>The Promise returned by Evaluate is allocated by the first invocation of Evaluate, and its capability is stored in the [[TopLevelCapability]] field. If execution results in an exception, the Promise is rejected. Future invocations of Evaluate return the same Promise.</ins></p>
 
     <p>This abstract method performs the following steps (most of the work is done by the auxiliary function InnerModuleEvaluation):</p>
 


### PR DESCRIPTION
This paragraph caused confusion when V8 was implementing TLA. TLA
changes Evaluate to *always* return a Promise, so the part about
"rethrown by future invocations of Evaluate" is particularly confusing.

(Confusing enough that the current implementation in V8 is buggy: it both throws and rejects.)