### PR TITLE
Update contributors list in spec text

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -6,7 +6,7 @@ status: proposal
 stage: 3
 location: https://tc39.github.io/proposal-top-level-await/
 copyright: false
-contributors: Myles Borins, Guy Bedford, Daniel Ehrenberg
+contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ger, and others.
 </pre>
 <script src="ecmarkup.js" defer></script>
 <link rel="stylesheet" href="ecmarkup.css">


### PR DESCRIPTION
This updates the list of contributors in the actual spec text itself to match the same contributors text as the readme. If this repo will soon be moving to stability, it seems worthwhile to have it be accurate.