### PR TITLE
Editorial: Reinstate "evaluating-async" state alongside AsyncEvaluating -> AsyncEvaluation

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -675,6 +675,9 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
     <emu-clause id="sec-async-module-execution-fulfilled" aoid="AsyncModuleExecutionFulfilled">
       <h1><ins>AsyncModuleExecutionFulfilled ( _module_ )</ins></h1>
       <emu-alg>
+        1. If _module_.[[Status]] is ~evaluated~,
+          1. Assert: _module_.[[EvaluationError]] is not ~empty~.
+          1. Return *undefined*.
         1. Assert: _module_.[[Status]] is ~evaluating-async~.
         1. Assert: _module_.[[QueuedEvaluation]] is *true*.
         1. Assert: _module_.[[EvaluationError]] is ~empty~.
@@ -711,6 +714,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
           1. Assert: _module_.[[EvaluationError]] is not ~empty~.
           1. Return *undefined*.
         1. Assert: _module_.[[Status]] is ~evaluating-async~.
+        1. Assert: _module_.[[QueuedEvaluation]] is *true*.
         1. Assert: _module_.[[EvaluationError]] is ~empty~.
         1. Set _module_.[[EvaluationError]] to ThrowCompletion(_error_).
         1. Set _module_.[[Status]] to ~evaluated~.

--- a/spec.html
+++ b/spec.html
@@ -776,15 +776,16 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
     <p><ins>Linking happens as before, and all modules end up with [[Status]] set to ~linked~.</ins></p>
 
     <p><ins>
-      Calling _A_.Evaluate() triggers InnerModuleEvaluation on _A_, _B_, and _D_.  which all transition to ~async-evaluating~.
-      Then InnerModuleEvaluation is called on _A_ again, which is a no-op because it is already ~async-evaluating~.
-      At this point, _D_.[[PendingAsyncDependencies]] is 0, so ExecuteAsyncModule(_D_) is called, which sets _D_.[[QueuedEvaluation]] to *true* and triggers the execution promise for _D_.
-      We unwind back to the original InnerModuleEvaluation on _A_, setting _B_.[[QueuedEvaluation]] to *true*.
+      Calling _A_.Evaluate() triggers InnerModuleEvaluation on _A_, _B_, and _D_.  which all transition to ~evaluating~.
+      Then InnerModuleEvaluation is called on _A_ again, which is a no-op because it is already ~evaluating~.
+      At this point, _D_.[[PendingAsyncDependencies]] is 0, so ExecuteAsyncModule(_D_) is called and triggers the execution promise for _D_.
+      We unwind back to the InnerModuleEvaluation on _B_, setting _B_.[[PendingAsyncDependencies]] to 1 and _B_.[[QueuedEvaluation]] to *true*.
+      We unwind back to the original InnerModuleEvaluation on _A_, setting _A_.[[PendingAsyncDependencies]] to 1.
       In the next iteration of the loop over _A_'s dependencies, we call InnerModuleEvaluation on _C_ and thus on _D_ (again a no-op) and _E_.
-      As _E_ has no dependencies, ExecuteAsyncModule(_E_) is called, which sets _E_.[[QueuedEvaluation]] to *true* and triggers its execution promise.
+      As _E_ has no dependencies, ExecuteAsyncModule(_E_) is called, which triggers its execution promise.
       Because _E_ is not part of a cycle, it is immediately removed from the stack and transitions to ~evaluated~.
       We unwind once more to the original InnerModuleEvaluation on _A_, setting _C_.[[QueuedEvaluation]] to *true*.
-      Now we finish the loop over _A_'s dependencies, set _A_.[[QueuedEvaluation]] to *true*, and remove the entire strongly connected component from the stack, transitioning all of the modules to ~evaluated~ at once.
+      Now we finish the loop over _A_'s dependencies, set _A_.[[QueuedEvaluation]] to *true*, and remove the entire strongly connected component from the stack, transitioning all of the modules to ~async-evaluating~ at once.
       At this point, the fields of the modules are as given in <emu-xref href="#table-module-graph-cycle-async-fields-1"></emu-xref>.
     </ins></p>
 
@@ -795,6 +796,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>Module</th>
             <th>[[DFSIndex]]</th>
             <th>[[DFSAncestorIndex]]</th>
+            <th>[[Status]]</th>
             <th>[[QueuedEvaluation]]</th>
             <th>[[AsyncParentModules]]</th>
             <th>[[PendingAsyncDependencies]]</th>
@@ -805,6 +807,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>_A_</th>
             <td>0</td>
             <td>0</td>
+            <td>~async-evaluating~</td>
             <td>*true*</td>
             <td>&laquo; &raquo;</td>
             <td>2 (_B_ and _C_)</td>
@@ -813,6 +816,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>_B_</th>
             <td>1</td>
             <td>0</td>
+            <td>~async-evaluating~</td>
             <td>*true*</td>
             <td>&laquo; _A_ &raquo;</td>
             <td>1 (_D_)</td>
@@ -821,6 +825,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>_C_</th>
             <td>2</td>
             <td>0</td>
+            <td>~async-evaluating~</td>
             <td>*true*</td>
             <td>&laquo; _A_ &raquo;</td>
             <td>2 (_D_ and _E_)</td>
@@ -829,7 +834,8 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>_D_</th>
             <td>3</td>
             <td>0</td>
-            <td>*true*</td>
+            <td>~async-evaluating~</td>
+            <td>*false*</td>
             <td>&laquo; _B_, _C_ &raquo;</td>
             <td>0</td>
           </tr>
@@ -837,7 +843,8 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>_E_</th>
             <td>4</td>
             <td>4</td>
-            <td>*true*</td>
+            <td>~async-evaluating~</td>
+            <td>*false*</td>
             <td>&laquo; _C_ &raquo;</td>
             <td>0</td>
           </tr>
@@ -858,6 +865,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>Module</th>
             <th>[[DFSIndex]]</th>
             <th>[[DFSAncestorIndex]]</th>
+            <th>[[Status]]</th>
             <th>[[QueuedEvaluation]]</th>
             <th>[[AsyncParentModules]]</th>
             <th>[[PendingAsyncDependencies]]</th>
@@ -868,6 +876,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>_C_</th>
             <td>2</td>
             <td>0</td>
+            <td>~async-evaluating~</td>
             <td>*true*</td>
             <td>&laquo; _A_ &raquo;</td>
             <td>1 (_D_)</td>
@@ -876,7 +885,8 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>_E_</th>
             <td>4</td>
             <td>4</td>
-            <td>*true*</td>
+            <td>~evaluated~</td>
+            <td>*false*</td>
             <td>&laquo; _C_ &raquo;</td>
             <td>0</td>
           </tr>
@@ -888,7 +898,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
       _D_ is next to finish (as it was the only module that was still executing).
       When that happens, AsyncModuleExecutionFulfilled is called again and _D_.[[State]] is set to ~evaluated~.
       Then _B_.[[PendingAsyncDependencies]] is decremented to become 0, ExecuteAsyncModule is called on _B_, and its execution is triggered.
-      Once the synchronous part of _B_'s execution has finished, _C_.[[PendingAsyncDependencies]] is also decremented to become 0, and _C_'s execution is triggered.
+      _C_.[[PendingAsyncDependencies]] is also decremented to become 0, and _C_'s execution is triggered.
       The fields of the updated modules are as given in <emu-xref href="#table-module-graph-cycle-async-fields-3"></emu-xref>.
     </ins></p>
 
@@ -899,6 +909,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>Module</th>
             <th>[[DFSIndex]]</th>
             <th>[[DFSAncestorIndex]]</th>
+            <th>[[Status]]</th>
             <th>[[QueuedEvaluation]]</th>
             <th>[[AsyncParentModules]]</th>
             <th>[[PendingAsyncDependencies]]</th>
@@ -909,6 +920,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>_B_</th>
             <td>1</td>
             <td>0</td>
+            <td>~async-evaluating~</td>
             <td>*true*</td>
             <td>&laquo; _A_ &raquo;</td>
             <td>0</td>
@@ -917,6 +929,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>_C_</th>
             <td>2</td>
             <td>0</td>
+            <td>~async-evaluating~</td>
             <td>*true*</td>
             <td>&laquo; _A_ &raquo;</td>
             <td>0</td>
@@ -925,6 +938,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>_D_</th>
             <td>3</td>
             <td>0</td>
+            <td>~evaluated~</td>
             <td>*false*</td>
             <td>&laquo; _B_, _C_ &raquo;</td>
             <td>0</td>
@@ -946,6 +960,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>Module</th>
             <th>[[DFSIndex]]</th>
             <th>[[DFSAncestorIndex]]</th>
+            <th>[[Status]]</th>
             <th>[[QueuedEvaluation]]</th>
             <th>[[AsyncParentModules]]</th>
             <th>[[PendingAsyncDependencies]]</th>
@@ -956,6 +971,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>_A_</th>
             <td>0</td>
             <td>0</td>
+            <th>~async-evaluating~</th>
             <td>*true*</td>
             <td>&laquo; &raquo;</td>
             <td>1 (_B_)</td>
@@ -964,7 +980,8 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>_C_</th>
             <td>2</td>
             <td>0</td>
-            <td>*false*</td>
+            <th>~evaluated~</th>
+            <td>*true*</td>
             <td>&laquo; _A_ &raquo;</td>
             <td>0</td>
           </tr>
@@ -975,7 +992,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
     <p><ins>
       Then, _B_ finishes executing.
       When that happens, AsyncModuleExecutionFulfilled is called again and _B_.[[State]] is set to ~evaluated~.
-      _A_.[[PendingAsyncDependencies]] is decremented to become 0, so ExecuteAsyncModule is called and its execution is triggered.
+      _A_.[[PendingAsyncDependencies]] is decremented to become 0, so ExecuteAsyncModule is called and _A_'s execution is triggered.
       The fields of the updated modules are as given in <emu-xref href="#table-module-graph-cycle-async-fields-5"></emu-xref>.
     </ins></p>
 
@@ -986,6 +1003,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>Module</th>
             <th>[[DFSIndex]]</th>
             <th>[[DFSAncestorIndex]]</th>
+            <th>[[Status]]</th>
             <th>[[QueuedEvaluation]]</th>
             <th>[[AsyncParentModules]]</th>
             <th>[[PendingAsyncDependencies]]</th>
@@ -996,6 +1014,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>_A_</th>
             <td>0</td>
             <td>0</td>
+            <td>~async-evaluating~</td>
             <td>*true*</td>
             <td>&laquo; &raquo;</td>
             <td>0</td>
@@ -1004,7 +1023,8 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>_B_</th>
             <td>1</td>
             <td>0</td>
-            <td>*false*</td>
+            <td>~evaluated~</td>
+            <td>*true*</td>
             <td>&laquo; _A_ &raquo;</td>
             <td>0</td>
           </tr>
@@ -1026,6 +1046,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>Module</th>
             <th>[[DFSIndex]]</th>
             <th>[[DFSAncestorIndex]]</th>
+            <th>[[Status]]</th>
             <th>[[QueuedEvaluation]]</th>
             <th>[[AsyncParentModules]]</th>
             <th>[[PendingAsyncDependencies]]</th>
@@ -1036,7 +1057,8 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>_A_</th>
             <td>0</td>
             <td>0</td>
-            <td>*false*</td>
+            <td>~evaluated~</td>
+            <td>*true*</td>
             <td>&laquo; &raquo;</td>
             <td>0</td>
           </tr>
@@ -1045,7 +1067,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
     </emu-table>
 
     <p><ins>
-      Alternatively, consider a failure case where _C_ fails execution and returns an error before _B_ has finished executing. When that happens, AsyncModuleExecutionRejected is called and _C_.[[AsyncEvaluating]] is set to *false*. We then set the evaluation error of the module to the error returned by executing _C_. We then propagate this error to all of the AsyncParentModules by performing AsyncModuleExeutionRejected on each of them. The fields of the updated modules are as given in <emu-xref href="#table-module-graph-cycle-async-fields-7"></emu-xref>.
+      Alternatively, consider a failure case where _C_ fails execution and returns an error before _B_ has finished executing. When that happens, AsyncModuleExecutionRejected is called and _C_.[[Status]] is set to ~evaluated~. We then set the evaluation error of the module to the error returned by executing _C_. We then propagate this error to all of the AsyncParentModules by performing AsyncModuleExeutionRejected on each of them. The fields of the updated modules are as given in <emu-xref href="#table-module-graph-cycle-async-fields-7"></emu-xref>.
     </ins></p>
 
     <emu-table id="table-module-graph-cycle-async-fields-7" caption="Module fields after module _C_ finishes with an error">
@@ -1055,7 +1077,8 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>Module</th>
             <th>[[DFSIndex]]</th>
             <th>[[DFSAncestorIndex]]</th>
-            <th>[[AsyncEvaluating]]</th>
+            <th>[[Status]]</th>
+            <th>[[QueuedEvaluation]]</th>
             <th>[[AsyncParentModules]]</th>
             <th>[[PendingAsyncDependencies]]</th>
             <th>[[EvaluationError]]</th>
@@ -1066,6 +1089,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>_A_</th>
             <td>0</td>
             <td>0</td>
+            <td>~evaluated~</td>
             <td>*true*</td>
             <td>&laquo; &raquo;</td>
             <td>1 (_B_)</td>
@@ -1075,7 +1099,8 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>_C_</th>
             <td>2</td>
             <td>1</td>
-            <td>*false*</td>
+            <td>~evaluated~</td>
+            <td>*true*</td>
             <td>&laquo; _A_ &raquo;</td>
             <td>_C_'s evaluation error</td>
           </tr>
@@ -1094,7 +1119,8 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>Module</th>
             <th>[[DFSIndex]]</th>
             <th>[[DFSAncestorIndex]]</th>
-            <th>[[AsyncEvaluating]]</th>
+            <th>[[Status]]</th>
+            <th>[[QueuedEvaluation]]</th>
             <th>[[AsyncParentModules]]</th>
             <th>[[PendingAsyncDependencies]]</th>
             <th>[[EvaluationError]]</th>
@@ -1105,7 +1131,8 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>_A_</th>
             <td>0</td>
             <td>0</td>
-            <td>*false*</td>
+            <td>~evaluated~</td>
+            <td>*true*</td>
             <td>&laquo; &raquo;</td>
             <td>0</td>
             <td>_C_'s Evaluation Error</td>
@@ -1115,7 +1142,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
     </emu-table>
 
     <p><ins>
-      Then, _B_ finishes executing without an error. When that happens, AsyncModuleExecutionFulfilled is called again and _B_.[[AsyncEvaluating]] is set to *false*.  GatherAsyncParentCompletions is called on _B_. However, _A_.[[CycleRoot]] is _A_ which has an evaluation error, so it will not be added to the returned _sortedExecList_ and AsyncModuleExecutionFulfilled will return without further processing. Any future importer of _B_ will resolve the rejection of _B_.[[CycleRoot]].[[EvaluationError]] from the evaluation error from _C_ that was set on the cycle root _A_. The fields of the updated modules are as given in <emu-xref href="#table-module-graph-cycle-async-fields-9"></emu-xref>.
+      Then, _B_ finishes executing without an error. When that happens, AsyncModuleExecutionFulfilled is called again and _B_.[[Status]] is set to ~evaluated~.  GatherAsyncParentCompletions is called on _B_. However, _A_.[[CycleRoot]] is _A_ which has an evaluation error, so it will not be added to the returned _sortedExecList_ and AsyncModuleExecutionFulfilled will return without further processing. Any future importer of _B_ will resolve the rejection of _B_.[[CycleRoot]].[[EvaluationError]] from the evaluation error from _C_ that was set on the cycle root _A_. The fields of the updated modules are as given in <emu-xref href="#table-module-graph-cycle-async-fields-9"></emu-xref>.
     </ins></p>
 
     <emu-table id="table-module-graph-cycle-async-fields-5" caption="Module fields after module _B_ finishes executing in an erroring graph">
@@ -1125,7 +1152,8 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>Module</th>
             <th>[[DFSIndex]]</th>
             <th>[[DFSAncestorIndex]]</th>
-            <th>[[AsyncEvaluating]]</th>
+            <th>[[Status]]</th>
+            <th>[[QueuedEvaluation]]</th>
             <th>[[AsyncParentModules]]</th>
             <th>[[PendingAsyncDependencies]]</th>
             <th>[[EvaluationError]]</th>
@@ -1136,7 +1164,8 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>_A_</th>
             <td>0</td>
             <td>0</td>
-            <td>*false*</td>
+            <td>~evaluated~</td>
+            <td>*true*</td>
             <td>&laquo; &raquo;</td>
             <td>0</td>
             <td>_C_'s Evaluation Error</td>
@@ -1145,7 +1174,8 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>_B_</th>
             <td>1</td>
             <td>0</td>
-            <td>*false*</td>
+            <td>~evaluated~</td>
+            <td>*true*</td>
             <td>&laquo; _A_ &raquo;</td>
             <td>0</td>
             <td>~empty~</td>

--- a/spec.html
+++ b/spec.html
@@ -371,7 +371,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
           </td>
           <td>
             <ins>Whether this module is either itself async or has an asynchronous dependency.</ins>
-            <ins>Note: This order in which this field is set also acts as counter for ordering queued executions, see <emu-xref href="#sec-async-module-execution-fulfilled"></emu-xref>.</ins>
+            <ins>Note: The order in which this field is set is used to order queued executions, see <emu-xref href="#sec-async-module-execution-fulfilled"></emu-xref>.</ins>
           </td>
         </tr>
         <tr>
@@ -479,12 +479,11 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
       <h1>InnerModuleLinking ( _module_, _stack_, _index_ )</h1>
       <p>The abstract operation InnerModuleLinking takes arguments _module_ (a Cyclic Module Record), _stack_, and _index_. It is used by Link to perform the actual linking process for _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as a module's [[DFSIndex]] and [[DFSAncestorIndex]] fields, keep track of the depth-first search (DFS) traversal. In particular, [[DFSAncestorIndex]] is used to discover strongly connected components (SCCs), such that all modules in an SCC transition to ~linked~ together. It performs the following steps when called:</p>
 
-
       <emu-alg>
         1. If _module_ is not a Cyclic Module Record, then
           1. Perform ? _module_.Link().
           1. Return _index_.
-        1. If _module_.[[Status]] is ~linking~, ~linked~, or ~evaluated~, then
+        1. If _module_.[[Status]] is ~linking~, ~linked~<ins>, ~evaluating-async~</ins> or ~evaluated~, then
           1. Return _index_.
         1. Assert: _module_.[[Status]] is ~unlinked~.
         1. Set _module_.[[Status]] to ~linking~.
@@ -496,7 +495,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
           1. Let _requiredModule_ be ? HostResolveImportedModule(_module_, _required_).
           1. Set _index_ to ? InnerModuleLinking(_requiredModule_, _stack_, _index_).
           1. If _requiredModule_ is a Cyclic Module Record, then
-            1. Assert: _requiredModule_.[[Status]] is either ~linking~, ~linked~, or ~evaluated~.
+            1. Assert: _requiredModule_.[[Status]] is either ~linking~, ~linked~<ins>, ~evaluating-async~</ins> or ~evaluated~.
             1. Assert: _requiredModule_.[[Status]] is ~linking~ if and only if _requiredModule_ is in _stack_.
             1. If _requiredModule_.[[Status]] is ~linking~, then
               1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
@@ -594,13 +593,12 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
         1. <ins>If _module_.[[PendingAsyncDependencies]] &gt; 0 or _module_.[[Async]] is *true*, then</ins>
           1. <ins>Assert: _module_.[[QueuedEvaluation]] is *false*.</ins>
           1. <ins>Set _module_.[[QueuedEvaluation]] to *true*.</ins>
-          1. NOTE: The order in which [[QueuedEvaluation]] transitions to *true* is significant. (See <emu-xref href="#sec-async-module-execution-fulfilled"></emu-xref>)
+          1. <ins>NOTE: The order in which [[QueuedEvaluation]] transitions to *true* is significant. (See <emu-xref href="#sec-async-module-execution-fulfilled"></emu-xref>)</ins>
           1. <ins>If _module_.[[PendingAsyncDependencies]] is 0, perform ! ExecuteAsyncModule(_module_).</ins>
         1. <ins>Otherwise, perform ? _module_.ExecuteModule().</ins>
         1. Assert: _module_ occurs exactly once in _stack_.
         1. Assert: _module_.[[DFSAncestorIndex]] is less than or equal to _module_.[[DFSIndex]].
         1. If _module_.[[DFSAncestorIndex]] equals _module_.[[DFSIndex]], then
-          1. <ins>Let _cycleRoot_ be _module_.</ins>
           1. Let _done_ be *false*.
           1. Repeat, while _done_ is *false*,
             1. Let _requiredModule_ be the last element in _stack_.
@@ -609,7 +607,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             1. <ins>If _requiredModule_.[[QueuedEvaluation]] is *false*, set _requiredModule_.[[Status]] to ~evaluated~.</ins>
             1. <ins>Otherwise, set _requiredModule_.[[Status]] to ~evaluating-async~.</ins>
             1. If _requiredModule_ and _module_ are the same Module Record, set _done_ to *true*.
-            1. <ins>Set _requiredModule_.[[CycleRoot]] to _cycleRoot_.</ins>
+            1. <ins>Set _requiredModule_.[[CycleRoot]] to _module_.</ins>
         1. Return _index_.
       </emu-alg>
       <emu-note>
@@ -623,7 +621,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
     <emu-clause id="sec-execute-async-module" aoid="ExecuteAsyncModule">
       <h1><ins>ExecuteAsyncModule ( _module_ )</ins></h1>
       <emu-alg>
-        1. Assert: _module_.[[Status]] is ~evaluating-async~.
+        1. Assert: _module_.[[Status]] is ~evaluating~ or ~evaluating-async~.
         1. Assert: _module_.[[Async]] is *true*.
         1. Let _capability_ be ! NewPromiseCapability(%Promise%).
         1. Let _stepsFulfilled_ be the steps of a CallAsyncModuleFulfilled function as specified below.
@@ -657,16 +655,16 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
     <emu-clause id="sec-gather-async-parent-completions" aoid="GatherAsyncParentCompletions">
       <h1><ins>GatherAsyncParentCompletions ( _module_, _execList_ )</ins></h1>
       <emu-alg>
-        1. Assert: _module_.[[Status]] is ~evaluating-async~.
         1. For each Module _m_ of _module_.[[AsyncParentModules]], do
           1. If _execList_ does not contain _m_ and _m_.[[CycleRoot]].[[EvaluationError]] is ~empty~, then
-            1. Assert: _m_.[[EvaluationError]] is ~empty~.
             1. Assert: _m_.[[Status]] is ~evaluating-async~.
+            1. Assert: _m_.[[EvaluationError]] is ~empty~.
+            1. Assert: _m_.[[QueuedEvaluation]] is *true*.
             1. Assert: _m_.[[PendingAsyncDependencies]] > 0.
             1. Set _m_.[[PendingAsyncDependencies]] to _m_.[[PendingAsyncDependencies]] - 1.
             1. If _m_.[[PendingAsyncDependencies]] is equal to 0, then
-                1. Append _m_ to _execList_.
-                1. If _m_.[[Async]] is *false*, perform ! GatherAsyncParentCompletions(_m_, _execList_).
+              1. Append _m_ to _execList_.
+              1. If _m_.[[Async]] is *false*, perform ! GatherAsyncParentCompletions(_m_, _execList_).
         1. Return *undefined*.
       </emu-alg>
       <emu-note>
@@ -1107,7 +1105,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
     </emu-table>
 
     <p><ins>
-      _A_ will be rejected with the same error as _C_ since _C_ will call AsyncModuleExecutionRejected on _A_ with _C_'s error. _A_.[[AsyncEvaluating]] is set to *false*.  At this point the Promise in _A_.[[TopLevelCapability]] (which was returned from _A_.Evaluate()) is rejected. The fields of the updated module are as given in <emu-xref href="#table-module-graph-cycle-async-fields-8"></emu-xref>.
+      _A_ will be rejected with the same error as _C_ since _C_ will call AsyncModuleExecutionRejected on _A_ with _C_'s error. _A_.[[Status]] is set to ~evaluated~.  At this point the Promise in _A_.[[TopLevelCapability]] (which was returned from _A_.Evaluate()) is rejected. The fields of the updated module are as given in <emu-xref href="#table-module-graph-cycle-async-fields-8"></emu-xref>.
     </ins></p>
 
     <emu-table id="table-module-graph-cycle-async-fields-8" caption="Module fields after module _A_ is rejected">
@@ -1217,7 +1215,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
         1. Else,
           1. Append _ee_ to _indirectExportEntries_.
       1. <ins>Let _async_ be _body_ Contains `await`.</ins>
-      1. Return Source Text Module Record { [[Realm]]: _realm_, [[Environment]]: ~empty~, [[Namespace]]: ~empty~, <ins>[[CycleRoot]]: ~empty~, [[Async]]: _async_, [[QueuedEvaluation]]: ~empty~, [[TopLevelCapability]]: ~empty~, [[AsyncParentModules]]: &laquo; &raquo;, [[PendingAsyncDependencies]]: ~empty~, </ins>[[Status]]: ~unlinked~, [[EvaluationError]]: ~empty~, [[HostDefined]]: _hostDefined_, [[ECMAScriptCode]]: _body_, [[Context]]: ~empty~, [[ImportMeta]]: ~empty~, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[DFSIndex]]: ~empty~, [[DFSAncestorIndex]]: ~empty~ }.
+      1. Return Source Text Module Record { [[Realm]]: _realm_, [[Environment]]: ~empty~, [[Namespace]]: ~empty~, <ins>[[CycleRoot]]: ~empty~, [[Async]]: _async_, [[QueuedEvaluation]]: *false*, [[TopLevelCapability]]: ~empty~, [[AsyncParentModules]]: &laquo; &raquo;, [[PendingAsyncDependencies]]: ~empty~, </ins>[[Status]]: ~unlinked~, [[EvaluationError]]: ~empty~, [[HostDefined]]: _hostDefined_, [[ECMAScriptCode]]: _body_, [[Context]]: ~empty~, [[ImportMeta]]: ~empty~, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[DFSIndex]]: ~empty~, [[DFSAncestorIndex]]: ~empty~ }.
     </emu-alg>
     <emu-note>
       <p>An implementation may parse module source text and analyse it for Early Error conditions prior to the evaluation of ParseModule for that module source text. However, the reporting of any errors must be deferred until the point where this specification actually performs ParseModule upon that source text.</p>

--- a/spec.html
+++ b/spec.html
@@ -287,11 +287,11 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             [[Status]]
           </td>
           <td>
-            ~unlinked~ | ~linking~ | ~linked~ | ~evaluating~<ins> | ~async-evaluating~</ins> | ~evaluated~
+            ~unlinked~ | ~linking~ | ~linked~ | ~evaluating~<ins> | ~evaluating-async~</ins> | ~evaluated~
           </td>
           <td>
-            Initially ~unlinked~. Transitions to ~linking~, ~linked~, ~evaluating~, <ins>possibly ~async-evaluating~, </ins>~evaluated~ (in that order) as the module progresses throughout its lifecycle.
-            <ins>~async-evaluating~ indicates this module is queued to execute on completion of its async dependencies or it is an async module that has been executed and is pending top-level completion.</ins>
+            Initially ~unlinked~. Transitions to ~linking~, ~linked~, ~evaluating~, <ins>possibly ~evaluating-async~, </ins>~evaluated~ (in that order) as the module progresses throughout its lifecycle.
+            <ins>~evaluating-async~ indicates this module is queued to execute on completion of its async dependencies or it is an async module that has been executed and is pending top-level completion.</ins>
           </td>
         </tr>
         <tr>
@@ -470,7 +470,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
           1. Set _m_.[[Status]] to ~unlinked~.
         1. Assert: _module_.[[Status]] is ~unlinked~.
         1. Return _result_.
-      1. Assert: _module_.[[Status]] is ~linked~<ins>, ~async-evaluating~</ins> or ~evaluated~.
+      1. Assert: _module_.[[Status]] is ~linked~<ins>, ~evaluating-async~</ins> or ~evaluated~.
       1. Assert: _stack_ is empty.
       1. Return *undefined*.
     </emu-alg>
@@ -519,7 +519,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
   <emu-clause id="sec-moduleevaluation">
     <h1>Evaluate ( ) Concrete Method</h1>
     <p>The Evaluate concrete method of a Cyclic Module Record implements the corresponding Module Record abstract method.</p>
-    <p>Evaluate transitions this module's [[Status]] from ~linked~ to <ins>~async-evaluating~ or</ins>~evaluated~.</p>
+    <p>Evaluate transitions this module's [[Status]] from ~linked~ to <ins>~evaluating-async~ or</ins>~evaluated~.</p>
     <p><del>If execution results in an exception, that exception is recorded in the [[EvaluationError]] field and rethrown by future invocations of Evaluate.</del></p>
     <p><ins>The Promise returned by Evaluate is allocated by the first invocation of Evaluate, and its capability is stored in the [[TopLevelCapability]] field. If execution results in an exception, the Promise is rejected. Future invocations of Evaluate return the same Promise.</ins></p>
     <p>This abstract method performs the following steps (most of the work is done by the auxiliary function InnerModuleEvaluation):</p>
@@ -527,8 +527,8 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
     <emu-alg>
       1. Assert: This call to Evaluate is not happening at the same time as another call to Evaluate within the surrounding agent.
       1. Let _module_ be this Cyclic Module Record.
-      1. Assert: _module_.[[Status]] is ~linked~<ins>, ~async-evaluating~</ins> or ~evaluated~.
-      1. <ins>If _module_.[[Status]] is ~async-evaluating~ or ~evaluated~, set _module_ to _module_.[[CycleRoot]].</ins>
+      1. Assert: _module_.[[Status]] is ~linked~<ins>, ~evaluating-async~</ins> or ~evaluated~.
+      1. <ins>If _module_.[[Status]] is ~evaluating-async~ or ~evaluated~, set _module_ to _module_.[[CycleRoot]].</ins>
       1. <ins>If _module_.[[TopLevelCapability]] is not ~empty~, then</ins>
         1. <ins>Return _module_.[[TopLevelCapability]].[[Promise]].</ins>
       1. Let _stack_ be a new empty List.
@@ -544,7 +544,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
         1. <del>Return _result_.</del>
         1. <ins>Perform ! Call(_capability_.[[Reject]], *undefined*, &laquo; _result_.[[Value]] &raquo;).</ins>
       1. <ins>Otherwise,</ins>
-        1. Assert: _module_.[[Status]] is <ins>~async-evaluating~ or</ins>~evaluated~ and _module_.[[EvaluationError]] is ~empty~.
+        1. Assert: _module_.[[Status]] is <ins>~evaluating-async~ or</ins>~evaluated~ and _module_.[[EvaluationError]] is ~empty~.
         1. <ins>If _module_.[[QueuedEvaluation]] is *false*, then</ins>
           1. <ins>Assert: _module_.[[Status]] is ~evaluated~.</ins>
           1. <ins>Perform ! Call(_capability_.[[Resolve]], *undefined*, &laquo; *undefined* &raquo;).</ins>
@@ -563,7 +563,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
           1. If _promise_.[[PromiseState]] is ~rejected~, then
             1. Return ThrowCompletion(_promise_.[[PromiseStateResult]]).
           1. Return _index_.
-        1. If _module_.[[Status]] is ~evaluated~<ins> or ~async-evaluating~</ins>, then
+        1. If _module_.[[Status]] is ~evaluated~<ins> or ~evaluating-async~</ins>, then
           1. If _module_.[[EvaluationError]] is ~empty~, return _index_.
           1. Otherwise, return _module_.[[EvaluationError]].
         1. If _module_.[[Status]] is ~evaluating~, return _index_.
@@ -579,13 +579,13 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
           1. NOTE: Link must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
           1. Set _index_ to ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_).
           1. If _requiredModule_ is a Cyclic Module Record, then
-            1. Assert: _requiredModule_.[[Status]] is either ~evaluating~<ins>, ~async-evaluating~</ins> or ~evaluated~.
+            1. Assert: _requiredModule_.[[Status]] is either ~evaluating~<ins>, ~evaluating-async~</ins> or ~evaluated~.
             1. Assert: _requiredModule_.[[Status]] is ~evaluating~ if and only if _requiredModule_ is in _stack_.
             1. If _requiredModule_.[[Status]] is ~evaluating~, then
               1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
             1. <ins>Otherwise,</ins>
               1. <ins>Set _requiredModule_ to _requiredModule_.[[CycleRoot]].</ins>
-              1. <ins>Assert: _requiredModule_.[[Status]] is ~async-evaluating~ or ~evaluated~.</ins>
+              1. <ins>Assert: _requiredModule_.[[Status]] is ~evaluating-async~ or ~evaluated~.</ins>
               1. <ins>If _requiredModule_.[[EvaluationError]] is not ~empty~, return _requiredModule_.[[EvaluationError]].</ins>
             1. <ins>If _requiredModule_.[[QueuedEvaluation]] is *true*, then</ins>
               1. <ins>Set _module_.[[PendingAsyncDependencies]] to _module_.[[PendingAsyncDependencies]] + 1.</ins>
@@ -607,13 +607,13 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             1. Remove the last element of _stack_.
             1. Assert: _requiredModule_ is a Cyclic Module Record.
             1. <ins>If _requiredModule_.[[QueuedEvaluation]] is *false*, set _requiredModule_.[[Status]] to ~evaluated~.</ins>
-            1. <ins>Otherwise, set _requiredModule_.[[Status]] to ~async-evaluating~.</ins>
+            1. <ins>Otherwise, set _requiredModule_.[[Status]] to ~evaluating-async~.</ins>
             1. If _requiredModule_ and _module_ are the same Module Record, set _done_ to *true*.
             1. <ins>Set _requiredModule_.[[CycleRoot]] to _cycleRoot_.</ins>
         1. Return _index_.
       </emu-alg>
       <emu-note>
-        <p><ins>A module is ~evaluating~ while it is being traversed by InnerModuleEvaluation. A module is ~evaluated~ on execution completion or ~async-evaluating~ during execution if it is an asynchronous module.</ins></p>
+        <p><ins>A module is ~evaluating~ while it is being traversed by InnerModuleEvaluation. A module is ~evaluated~ on execution completion or ~evaluating-async~ during execution if it is an asynchronous module.</ins></p>
       </emu-note>
       <emu-note>
         <p><ins>Any modules depending on a module of an async cycle when that cycle is not ~evaluating~ will instead depend on the execution of the root of the cycle via [[CycleRoot]]. This ensures that the cycle state can be treated as a single strongly connected component through its root module state.</ins></p>
@@ -623,7 +623,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
     <emu-clause id="sec-execute-async-module" aoid="ExecuteAsyncModule">
       <h1><ins>ExecuteAsyncModule ( _module_ )</ins></h1>
       <emu-alg>
-        1. Assert: _module_.[[Status]] is ~async-evaluating~.
+        1. Assert: _module_.[[Status]] is ~evaluating-async~.
         1. Assert: _module_.[[Async]] is *true*.
         1. Let _capability_ be ! NewPromiseCapability(%Promise%).
         1. Let _stepsFulfilled_ be the steps of a CallAsyncModuleFulfilled function as specified below.
@@ -657,11 +657,11 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
     <emu-clause id="sec-gather-async-parent-completions" aoid="GatherAsyncParentCompletions">
       <h1><ins>GatherAsyncParentCompletions ( _module_, _execList_ )</ins></h1>
       <emu-alg>
-        1. Assert: _module_.[[Status]] is ~async-evaluating~.
+        1. Assert: _module_.[[Status]] is ~evaluating-async~.
         1. For each Module _m_ of _module_.[[AsyncParentModules]], do
           1. If _execList_ does not contain _m_ and _m_.[[CycleRoot]].[[EvaluationError]] is ~empty~, then
             1. Assert: _m_.[[EvaluationError]] is ~empty~.
-            1. Assert: _m_.[[Status]] is ~async-evaluating~.
+            1. Assert: _m_.[[Status]] is ~evaluating-async~.
             1. Assert: _m_.[[PendingAsyncDependencies]] > 0.
             1. Set _m_.[[PendingAsyncDependencies]] to _m_.[[PendingAsyncDependencies]] - 1.
             1. If _m_.[[PendingAsyncDependencies]] is equal to 0, then
@@ -677,7 +677,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
     <emu-clause id="sec-async-module-execution-fulfilled" aoid="AsyncModuleExecutionFulfilled">
       <h1><ins>AsyncModuleExecutionFulfilled ( _module_ )</ins></h1>
       <emu-alg>
-        1. Assert: _module_.[[Status]] is ~async-evaluating~.
+        1. Assert: _module_.[[Status]] is ~evaluating-async~.
         1. Assert: _module_.[[QueuedEvaluation]] is *true*.
         1. Assert: _module_.[[EvaluationError]] is ~empty~.
         1. Set _module_.[[Status]] to ~evaluated~.
@@ -712,7 +712,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
         1. If _module_.[[Status]] is ~evaluated~,
           1. Assert: _module_.[[EvaluationError]] is not ~empty~.
           1. Return *undefined*.
-        1. Assert: _module_.[[Status]] is ~async-evaluating~.
+        1. Assert: _module_.[[Status]] is ~evaluating-async~.
         1. Assert: _module_.[[EvaluationError]] is ~empty~.
         1. Set _module_.[[EvaluationError]] to ThrowCompletion(_error_).
         1. Set _module_.[[Status]] to ~evaluated~.
@@ -783,7 +783,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
       As _E_ has no dependencies, ExecuteAsyncModule(_E_) is called, which triggers its execution promise.
       Because _E_ is not part of a cycle, it is immediately removed from the stack and transitions to ~evaluated~.
       We unwind once more to the original InnerModuleEvaluation on _A_, setting _C_.[[QueuedEvaluation]] to *true*.
-      Now we finish the loop over _A_'s dependencies, set _A_.[[QueuedEvaluation]] to *true*, and remove the entire strongly connected component from the stack, transitioning all of the modules to ~async-evaluating~ at once.
+      Now we finish the loop over _A_'s dependencies, set _A_.[[QueuedEvaluation]] to *true*, and remove the entire strongly connected component from the stack, transitioning all of the modules to ~evaluating-async~ at once.
       At this point, the fields of the modules are as given in <emu-xref href="#table-module-graph-cycle-async-fields-1"></emu-xref>.
     </ins></p>
 
@@ -805,7 +805,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>_A_</th>
             <td>0</td>
             <td>0</td>
-            <td>~async-evaluating~</td>
+            <td>~evaluating-async~</td>
             <td>*true*</td>
             <td>&laquo; &raquo;</td>
             <td>2 (_B_ and _C_)</td>
@@ -814,7 +814,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>_B_</th>
             <td>1</td>
             <td>0</td>
-            <td>~async-evaluating~</td>
+            <td>~evaluating-async~</td>
             <td>*true*</td>
             <td>&laquo; _A_ &raquo;</td>
             <td>1 (_D_)</td>
@@ -823,7 +823,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>_C_</th>
             <td>2</td>
             <td>0</td>
-            <td>~async-evaluating~</td>
+            <td>~evaluating-async~</td>
             <td>*true*</td>
             <td>&laquo; _A_ &raquo;</td>
             <td>2 (_D_ and _E_)</td>
@@ -832,7 +832,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>_D_</th>
             <td>3</td>
             <td>0</td>
-            <td>~async-evaluating~</td>
+            <td>~evaluating-async~</td>
             <td>*true*</td>
             <td>&laquo; _B_, _C_ &raquo;</td>
             <td>0</td>
@@ -841,7 +841,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>_E_</th>
             <td>4</td>
             <td>4</td>
-            <td>~async-evaluating~</td>
+            <td>~evaluating-async~</td>
             <td>*true*</td>
             <td>&laquo; _C_ &raquo;</td>
             <td>0</td>
@@ -874,7 +874,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>_C_</th>
             <td>2</td>
             <td>0</td>
-            <td>~async-evaluating~</td>
+            <td>~evaluating-async~</td>
             <td>*true*</td>
             <td>&laquo; _A_ &raquo;</td>
             <td>1 (_D_)</td>
@@ -918,7 +918,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>_B_</th>
             <td>1</td>
             <td>0</td>
-            <td>~async-evaluating~</td>
+            <td>~evaluating-async~</td>
             <td>*true*</td>
             <td>&laquo; _A_ &raquo;</td>
             <td>0</td>
@@ -927,7 +927,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>_C_</th>
             <td>2</td>
             <td>0</td>
-            <td>~async-evaluating~</td>
+            <td>~evaluating-async~</td>
             <td>*true*</td>
             <td>&laquo; _A_ &raquo;</td>
             <td>0</td>
@@ -969,7 +969,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>_A_</th>
             <td>0</td>
             <td>0</td>
-            <th>~async-evaluating~</th>
+            <th>~evaluating-async~</th>
             <td>*true*</td>
             <td>&laquo; &raquo;</td>
             <td>1 (_B_)</td>
@@ -1012,7 +1012,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>_A_</th>
             <td>0</td>
             <td>0</td>
-            <td>~async-evaluating~</td>
+            <td>~evaluating-async~</td>
             <td>*true*</td>
             <td>&laquo; &raquo;</td>
             <td>0</td>

--- a/spec.html
+++ b/spec.html
@@ -364,13 +364,13 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
         </tr>
         <tr>
           <td>
-            <ins>[[AsyncEvaluation]]</ins>
+            <ins>[[QueuedEvaluation]]</ins>
           </td>
           <td>
             <ins>*true* | *false* | ~empty~</ins>
           </td>
           <td>
-            <ins>Whether this module is either itself async or has an asynchronous dependency.</ins>
+            <ins>Whether this module has one or more asynchronous dependencies so that its evaluation is queued on their completion.</ins>
           </td>
         </tr>
         <tr>
@@ -544,7 +544,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
         1. <ins>Perform ! Call(_capability_.[[Reject]], *undefined*, &laquo; _result_.[[Value]] &raquo;).</ins>
       1. <ins>Otherwise,</ins>
         1. Assert: _module_.[[Status]] is <ins>~async-evaluating~ or</ins>~evaluated~ and _module_.[[EvaluationError]] is ~empty~.
-        1. <ins>If _module_.[[AsyncEvaluation]] is *false*, then</ins>
+        1. <ins>If _module_.[[Async]] is *false* and _module_.[[QueuedEvaluation]] is *false*, then</ins>
           1. <ins>Assert: _module_.[[Status]] is ~evaluated~.</ins>
           1. <ins>Perform ! Call(_capability_.[[Resolve]], *undefined*, &laquo; *undefined* &raquo;).</ins>
         1. Assert: _stack_ is empty.
@@ -554,7 +554,6 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
     <emu-clause id="sec-innermoduleevaluation" aoid="InnerModuleEvaluation">
       <h1>InnerModuleEvaluation ( _module_, _stack_, _index_ )</h1>
       <p>The abstract operation InnerModuleEvaluation takes arguments _module_ (a Source Text Module Record), _stack_, and _index_. It is used by Evaluate to perform the actual evaluation process for _module_, as well as recursively on all other modules in the dependency graph. The _stack_ and _index_ parameters, as well as _module_'s [[DFSIndex]] and [[DFSAncestorIndex]] fields, are used the same way as in InnerModuleLinking. It performs the following steps when called:</p>
-
 
       <emu-alg>
         1. If _module_ is not a Cyclic Module Record, then
@@ -587,18 +586,18 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
               1. <ins>Set _requiredModule_ to _requiredModule_.[[CycleRoot]].</ins>
               1. <ins>Assert: _requiredModule_.[[Status]] is ~async-evaluating~ or ~evaluated~.</ins>
               1. <ins>If _requiredModule_.[[EvaluationError]] is not ~empty~, return _requiredModule_.[[EvaluationError]].</ins>
-            1. <ins>If _requiredModule_.[[AsyncEvaluation]] is *true*, then</ins>
+            1. <ins>If _requiredModule_.[[Async]] is *true* or _requiredModule_.[[QueuedEvaluation]] is *true*, then</ins>
               1. <ins>Set _module_.[[PendingAsyncDependencies]] to _module_.[[PendingAsyncDependencies]] + 1.</ins>
               1. <ins>Append _module_ to _requiredModule_.[[AsyncParentModules]].</ins>
         1. <del>Perform ? _module_.ExecuteModule().</del>
-        1. <ins>If _module_.[[PendingAsyncDependencies]] &gt; 0 or _module_.[[Async]] is *true*, then</ins>
-          1. <ins>Assert: _module_.[[AsyncEvaluation]] is ~empty~.</ins>
-          1. <ins>Set _module_.[[AsyncEvaluation]] to *true*.</ins>
-          1. NOTE: The order in which [[AsyncEvaluation]] transitions to *true* is significant. (See <emu-xref href="#sec-async-module-execution-fulfilled"></emu-xref>)
-          1. <ins>If _module_.[[PendingAsyncDependencies]] is 0, perform ! ExecuteAsyncModule(_module_).</ins>
+        1. <ins>If _module_.[[PendingAsyncDependencies]] &gt; 0, then</ins>
+          1. <ins>Assert: _module_.[[QueuedEvaluation]] is ~empty~.</ins>
+          1. <ins>Set _module_.[[QueuedEvaluation]] to *true*.</ins>
+          1. NOTE: The order in which [[QueuedEvaluation]] transitions to *true* is significant. (See <emu-xref href="#sec-async-module-execution-fulfilled"></emu-xref>)
         1. <ins>Otherwise,</ins>
-          1. <ins>Set _module_.[[AsyncEvaluation]] to *false*.</ins>
-          1. <ins>Perform ? _module_.ExecuteModule().</ins>
+          1. <ins>Set _module_.[[QueuedEvaluation]] to *false*.</ins>
+          1. <ins>If _module_.[[Async]] is *true*, perform ! ExecuteAsyncModule(_module_).</ins>
+          1. <ins>Otherwise, perform ? _module_.ExecuteModule().</ins>
         1. Assert: _module_ occurs exactly once in _stack_.
         1. Assert: _module_.[[DFSAncestorIndex]] is less than or equal to _module_.[[DFSIndex]].
         1. If _module_.[[DFSAncestorIndex]] equals _module_.[[DFSIndex]], then
@@ -608,7 +607,8 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             1. Let _requiredModule_ be the last element in _stack_.
             1. Remove the last element of _stack_.
             1. Assert: _requiredModule_ is a Cyclic Module Record.
-            1. <ins>If _requiredModule_.[[AsyncEvaluation]] is *false*, set _requiredModule_.[[Status]] to ~evaluated~.
+            1. <ins>Assert: _requiredModule_.[[QueuedEvaluation]] is not ~empty~.</ins>
+            1. <ins>If _requiredModule_.[[QueuedEvaluation]] is *false*, set _requiredModule_.[[Status]] to ~evaluated~.</ins>
             1. <ins>Otherwise, set _requiredModule_.[[Status]] to ~async-evaluating~.</ins>
             1. If _requiredModule_ and _module_ are the same Module Record, set _done_ to *true*.
             1. <ins>Set _requiredModule_.[[CycleRoot]] to _cycleRoot_.</ins>
@@ -680,7 +680,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
       <h1><ins>AsyncModuleExecutionFulfilled ( _module_ )</ins></h1>
       <emu-alg>
         1. Assert: _module_.[[Status]] is ~async-evaluating~.
-        1. Assert: _module_.[[AsyncEvaluation]] is *true*.
+        1. Assert: _module_.[[Async]] is *true* or _module_.[[QueuedEvaluation]] is *true*.
         1. Assert: _module_.[[EvaluationError]] is ~empty~.
         1. Set _module_.[[Status]] to ~evaluated~.
         1. If _module_.[[TopLevelCapability]] is not ~empty~, then
@@ -688,8 +688,8 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
           1. Perform ! Call(_module_.[[TopLevelCapability]].[[Resolve]], *undefined*, &laquo;*undefined*&raquo;).
         1. Let _execList_ be a new empty List.
         1. Perform ! GatherAsyncParentCompletions(_module_, _execList_).
-        1. Let _sortedExecList_ be a List of elements that are the elements of _execList_, in the order in which they had their [[AsyncEvaluation]] fields set to *true* in InnerModuleEvaluation.
-        1. Assert: All elements of _sortedExecList_ have their [[AsyncEvaluation]] field set to *true*, [[PendingAsyncDependencies]] field set to 0 and [[EvaluationError]] field set to *undefined*.
+        1. Let _sortedExecList_ be a List of elements that are the elements of _execList_, in the order in which they had their [[QueuedEvaluation]] fields set to *true* in InnerModuleEvaluation.
+        1. Assert: All elements of _sortedExecList_ have their [[QueuedEvaluation]] field set to *true*, [[PendingAsyncDependencies]] field set to 0 and [[EvaluationError]] field set to *undefined*.
         1. For each Module _m_ of _sortedExecList_, do
           1. If _m_.[[Status]] is ~evaluated~, then
             1. Assert: _m_.[[EvaluationError]] is not ~empty~.
@@ -776,15 +776,15 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
     <p><ins>Linking happens as before, and all modules end up with [[Status]] set to ~linked~.</ins></p>
 
     <p><ins>
-      Calling _A_.Evaluate() triggers InnerModuleEvaluation on _A_, _B_, and _D_, which all transition to ~evaluating~.
-      Then InnerModuleEvaluation is called on _A_ again, which is a no-op because it is already ~evaluating~.
-      At this point, _D_.[[PendingAsyncDependencies]] is 0, so ExecuteAsyncModule(_D_) is called, which sets _D_.[[AsyncEvaluation]] to *true* and triggers the execution promise for _D_.
-      We unwind back to the original InnerModuleEvaluation on _A_, setting _B_.[[AsyncEvaluation]] to *true*.
+      Calling _A_.Evaluate() triggers InnerModuleEvaluation on _A_, _B_, and _D_.  which all transition to ~async-evaluating~.
+      Then InnerModuleEvaluation is called on _A_ again, which is a no-op because it is already ~async-evaluating~.
+      At this point, _D_.[[PendingAsyncDependencies]] is 0, so ExecuteAsyncModule(_D_) is called, which sets _D_.[[QueuedEvaluation]] to *true* and triggers the execution promise for _D_.
+      We unwind back to the original InnerModuleEvaluation on _A_, setting _B_.[[QueuedEvaluation]] to *true*.
       In the next iteration of the loop over _A_'s dependencies, we call InnerModuleEvaluation on _C_ and thus on _D_ (again a no-op) and _E_.
-      As _E_ has no dependencies, ExecuteAsyncModule(_E_) is called, which sets _E_.[[AsyncEvaluation]] to *true* and triggers its execution promise.
+      As _E_ has no dependencies, ExecuteAsyncModule(_E_) is called, which sets _E_.[[QueuedEvaluation]] to *true* and triggers its execution promise.
       Because _E_ is not part of a cycle, it is immediately removed from the stack and transitions to ~evaluated~.
-      We unwind once more to the original InnerModuleEvaluation on _A_, setting _C_.[[AsyncEvaluation]] to *true*.
-      Now we finish the loop over _A_'s dependencies, set _A_.[[AsyncEvaluation]] to *true*, and remove the entire strongly connected component from the stack, transitioning all of the modules to ~evaluated~ at once.
+      We unwind once more to the original InnerModuleEvaluation on _A_, setting _C_.[[QueuedEvaluation]] to *true*.
+      Now we finish the loop over _A_'s dependencies, set _A_.[[QueuedEvaluation]] to *true*, and remove the entire strongly connected component from the stack, transitioning all of the modules to ~evaluated~ at once.
       At this point, the fields of the modules are as given in <emu-xref href="#table-module-graph-cycle-async-fields-1"></emu-xref>.
     </ins></p>
 
@@ -795,7 +795,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>Module</th>
             <th>[[DFSIndex]]</th>
             <th>[[DFSAncestorIndex]]</th>
-            <th>[[AsyncEvaluation]]</th>
+            <th>[[QueuedEvaluation]]</th>
             <th>[[AsyncParentModules]]</th>
             <th>[[PendingAsyncDependencies]]</th>
           </tr>
@@ -858,7 +858,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>Module</th>
             <th>[[DFSIndex]]</th>
             <th>[[DFSAncestorIndex]]</th>
-            <th>[[AsyncEvaluation]]</th>
+            <th>[[QueuedEvaluation]]</th>
             <th>[[AsyncParentModules]]</th>
             <th>[[PendingAsyncDependencies]]</th>
           </tr>
@@ -899,7 +899,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>Module</th>
             <th>[[DFSIndex]]</th>
             <th>[[DFSAncestorIndex]]</th>
-            <th>[[AsyncEvaluation]]</th>
+            <th>[[QueuedEvaluation]]</th>
             <th>[[AsyncParentModules]]</th>
             <th>[[PendingAsyncDependencies]]</th>
           </tr>
@@ -946,7 +946,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>Module</th>
             <th>[[DFSIndex]]</th>
             <th>[[DFSAncestorIndex]]</th>
-            <th>[[AsyncEvaluation]]</th>
+            <th>[[QueuedEvaluation]]</th>
             <th>[[AsyncParentModules]]</th>
             <th>[[PendingAsyncDependencies]]</th>
           </tr>
@@ -986,7 +986,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>Module</th>
             <th>[[DFSIndex]]</th>
             <th>[[DFSAncestorIndex]]</th>
-            <th>[[AsyncEvaluation]]</th>
+            <th>[[QueuedEvaluation]]</th>
             <th>[[AsyncParentModules]]</th>
             <th>[[PendingAsyncDependencies]]</th>
           </tr>
@@ -1026,7 +1026,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>Module</th>
             <th>[[DFSIndex]]</th>
             <th>[[DFSAncestorIndex]]</th>
-            <th>[[AsyncEvaluation]]</th>
+            <th>[[QueuedEvaluation]]</th>
             <th>[[AsyncParentModules]]</th>
             <th>[[PendingAsyncDependencies]]</th>
           </tr>
@@ -1189,7 +1189,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
         1. Else,
           1. Append _ee_ to _indirectExportEntries_.
       1. <ins>Let _async_ be _body_ Contains `await`.</ins>
-      1. Return Source Text Module Record { [[Realm]]: _realm_, [[Environment]]: ~empty~, [[Namespace]]: ~empty~, <ins>[[CycleRoot]]: ~empty~, [[Async]]: _async_, [[AsyncEvaluation]]: ~empty~, [[TopLevelCapability]]: ~empty~, [[AsyncParentModules]]: &laquo; &raquo;, [[PendingAsyncDependencies]]: ~empty~, </ins>[[Status]]: ~unlinked~, [[EvaluationError]]: ~empty~, [[HostDefined]]: _hostDefined_, [[ECMAScriptCode]]: _body_, [[Context]]: ~empty~, [[ImportMeta]]: ~empty~, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[DFSIndex]]: ~empty~, [[DFSAncestorIndex]]: ~empty~ }.
+      1. Return Source Text Module Record { [[Realm]]: _realm_, [[Environment]]: ~empty~, [[Namespace]]: ~empty~, <ins>[[CycleRoot]]: ~empty~, [[Async]]: _async_, [[QueuedEvaluation]]: ~empty~, [[TopLevelCapability]]: ~empty~, [[AsyncParentModules]]: &laquo; &raquo;, [[PendingAsyncDependencies]]: ~empty~, </ins>[[Status]]: ~unlinked~, [[EvaluationError]]: ~empty~, [[HostDefined]]: _hostDefined_, [[ECMAScriptCode]]: _body_, [[Context]]: ~empty~, [[ImportMeta]]: ~empty~, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[DFSIndex]]: ~empty~, [[DFSAncestorIndex]]: ~empty~ }.
     </emu-alg>
     <emu-note>
       <p>An implementation may parse module source text and analyse it for Early Error conditions prior to the evaluation of ParseModule for that module source text. However, the reporting of any errors must be deferred until the point where this specification actually performs ParseModule upon that source text.</p>

--- a/spec.html
+++ b/spec.html
@@ -356,7 +356,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <ins>[[Async]]</ins>
           </td>
           <td>
-            <ins>*true* or *false*</ins>
+            <ins>Boolean</ins>
           </td>
           <td>
             <ins>Whether this module is individually asynchronous (for example, if it's a Source Text Module Record containing a top-level await). Having an asynchronous dependency does not make the module asynchronous. This field must not change after the module is parsed.</ins>
@@ -367,10 +367,11 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <ins>[[QueuedEvaluation]]</ins>
           </td>
           <td>
-            <ins>*true* | *false* | ~empty~</ins>
+            <ins>Boolean</ins>
           </td>
           <td>
             <ins>Whether this module is either itself async or has an asynchronous dependency.</ins>
+            <ins>Note: This order in which this field is set also acts as counter for ordering queued executions, see <emu-xref href="#sec-async-module-execution-fulfilled"></emu-xref>.</ins>
           </td>
         </tr>
         <tr>
@@ -591,13 +592,11 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
               1. <ins>Append _module_ to _requiredModule_.[[AsyncParentModules]].</ins>
         1. <del>Perform ? _module_.ExecuteModule().</del>
         1. <ins>If _module_.[[PendingAsyncDependencies]] &gt; 0 or _module_.[[Async]] is *true*, then</ins>
-          1. <ins>Assert: _module_.[[QueuedEvaluation]] is ~empty~.</ins>
+          1. <ins>Assert: _module_.[[QueuedEvaluation]] is *false*.</ins>
           1. <ins>Set _module_.[[QueuedEvaluation]] to *true*.</ins>
           1. NOTE: The order in which [[QueuedEvaluation]] transitions to *true* is significant. (See <emu-xref href="#sec-async-module-execution-fulfilled"></emu-xref>)
           1. <ins>If _module_.[[PendingAsyncDependencies]] is 0, perform ! ExecuteAsyncModule(_module_).</ins>
-        1. <ins>Otherwise,</ins>
-          1. <ins>Set _module_.[[QueuedEvaluation]] to *false*.</ins>
-          1. <ins>Perform ? _module_.ExecuteModule().</ins>
+        1. <ins>Otherwise, perform ? _module_.ExecuteModule().</ins>
         1. Assert: _module_ occurs exactly once in _stack_.
         1. Assert: _module_.[[DFSAncestorIndex]] is less than or equal to _module_.[[DFSIndex]].
         1. If _module_.[[DFSAncestorIndex]] equals _module_.[[DFSIndex]], then
@@ -607,7 +606,6 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             1. Let _requiredModule_ be the last element in _stack_.
             1. Remove the last element of _stack_.
             1. Assert: _requiredModule_ is a Cyclic Module Record.
-            1. <ins>Assert: _requiredModule_.[[QueuedEvaluation]] is not ~empty~.</ins>
             1. <ins>If _requiredModule_.[[QueuedEvaluation]] is *false*, set _requiredModule_.[[Status]] to ~evaluated~.</ins>
             1. <ins>Otherwise, set _requiredModule_.[[Status]] to ~async-evaluating~.</ins>
             1. If _requiredModule_ and _module_ are the same Module Record, set _done_ to *true*.

--- a/spec.html
+++ b/spec.html
@@ -772,7 +772,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
     <p><ins>Linking happens as before, and all modules end up with [[Status]] set to ~linked~.</ins></p>
 
     <p><ins>
-      Calling _A_.Evaluate() triggers InnerModuleEvaluation on _A_, _B_, and _D_.  which all transition to ~evaluating~.
+      Calling _A_.Evaluate() triggers InnerModuleEvaluation on _A_, _B_, and _D_, which all transition to ~evaluating~.
       Then InnerModuleEvaluation is called on _A_ again, which is a no-op because it is already ~evaluating~.
       At this point, _D_.[[PendingAsyncDependencies]] is 0, so ExecuteAsyncModule(_D_) is called and triggers the execution promise for _D_.
       We unwind back to the InnerModuleEvaluation on _B_, setting _B_.[[PendingAsyncDependencies]] to 1 and _B_.[[QueuedEvaluation]] to *true*.

--- a/spec.html
+++ b/spec.html
@@ -287,10 +287,11 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             [[Status]]
           </td>
           <td>
-            ~unlinked~ | ~linking~ | ~linked~ | ~evaluating~ | ~evaluated~
+            ~unlinked~ | ~linking~ | ~linked~ | ~evaluating~<ins> | ~async-evaluating~</ins> | ~evaluated~
           </td>
           <td>
-            Initially ~unlinked~. Transitions to ~linking~, ~linked~, ~evaluating~, ~evaluated~ (in that order) as the module progresses throughout its lifecycle.
+            Initially ~unlinked~. Transitions to ~linking~, ~linked~, ~evaluating~, <ins>possibly ~async-evaluating~, </ins>~evaluated~ (in that order) as the module progresses throughout its lifecycle.
+            <ins>~async-evaluating~ indicates this module is queued to execute on completion of its async dependencies or it is an async module that has been executed and is pending top-level completion.</ins>
           </td>
         </tr>
         <tr>
@@ -313,7 +314,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
           </td>
           <td>
             Auxiliary field used during Link and Evaluate only.
-            If [[Status]] is ~linking~<del> or</del><ins>,</ins> ~evaluating~<ins>, or ~evaluated~</ins>, this nonnegative number records the point at which the module was first visited during the depth-first traversal of the dependency graph.
+            If [[Status]] is ~linking~ or ~evaluating~, this nonnegative number records the point at which the module was first visited during the depth-first traversal of the dependency graph.
           </td>
         </tr>
         <tr>
@@ -325,7 +326,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
           </td>
           <td>
             Auxiliary field used during Link and Evaluate only.
-            If [[Status]] is ~linking~<del> or</del><ins>,</ins> ~evaluating~<ins>, or ~evaluated~</ins>, this is either the module's own [[DFSIndex]] or that of an "earlier" module in the same strongly connected component.
+            If [[Status]] is ~linking~ or ~evaluating~, this is either the module's own [[DFSIndex]] or that of an "earlier" module in the same strongly connected component.
           </td>
         </tr>
         <tr>
@@ -363,13 +364,13 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
         </tr>
         <tr>
           <td>
-            <ins>[[AsyncEvaluating]]</ins>
+            <ins>[[AsyncEvaluation]]</ins>
           </td>
           <td>
-            <ins>*true* or *false*</ins>
+            <ins>*true* | *false* | ~empty~</ins>
           </td>
           <td>
-            <ins>Whether this module is queued to execute on completion of its async dependencies or it is an async module that is currently executing but pending top-level completion.</ins>
+            <ins>Whether this module is either itself async or has an asynchronous dependency.</ins>
           </td>
         </tr>
         <tr>
@@ -468,7 +469,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
           1. Set _m_.[[Status]] to ~unlinked~.
         1. Assert: _module_.[[Status]] is ~unlinked~.
         1. Return _result_.
-      1. Assert: _module_.[[Status]] is ~linked~ or ~evaluated~.
+      1. Assert: _module_.[[Status]] is ~linked~<ins>, ~async-evaluating~</ins> or ~evaluated~.
       1. Assert: _stack_ is empty.
       1. Return *undefined*.
     </emu-alg>
@@ -517,7 +518,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
   <emu-clause id="sec-moduleevaluation">
     <h1>Evaluate ( ) Concrete Method</h1>
     <p>The Evaluate concrete method of a Cyclic Module Record implements the corresponding Module Record abstract method.</p>
-    <p>Evaluate transitions this module's [[Status]] from ~linked~ to ~evaluated~.</p>
+    <p>Evaluate transitions this module's [[Status]] from ~linked~ to <ins>~async-evaluating~ or</ins>~evaluated~.</p>
     <p><del>If execution results in an exception, that exception is recorded in the [[EvaluationError]] field and rethrown by future invocations of Evaluate.</del></p>
     <p><ins>The Promise returned by Evaluate is allocated by the first invocation of Evaluate, and its capability is stored in the [[TopLevelCapability]] field. If execution results in an exception, the Promise is rejected. Future invocations of Evaluate return the same Promise.</ins></p>
     <p>This abstract method performs the following steps (most of the work is done by the auxiliary function InnerModuleEvaluation):</p>
@@ -525,8 +526,8 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
     <emu-alg>
       1. Assert: This call to Evaluate is not happening at the same time as another call to Evaluate within the surrounding agent.
       1. Let _module_ be this Cyclic Module Record.
-      1. Assert: _module_.[[Status]] is ~linked~ or ~evaluated~.
-      1. <ins>If _module_.[[Status]] is ~evaluated~, set _module_ to _module_.[[CycleRoot]].</ins>
+      1. Assert: _module_.[[Status]] is ~linked~<ins>, ~async-evaluating~</ins> or ~evaluated~.
+      1. <ins>If _module_.[[Status]] is ~async-evaluating~ or ~evaluated~, set _module_ to _module_.[[CycleRoot]].</ins>
       1. <ins>If _module_.[[TopLevelCapability]] is not ~empty~, then</ins>
         1. <ins>Return _module_.[[TopLevelCapability]].[[Promise]].</ins>
       1. Let _stack_ be a new empty List.
@@ -542,8 +543,9 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
         1. <del>Return _result_.</del>
         1. <ins>Perform ! Call(_capability_.[[Reject]], *undefined*, &laquo; _result_.[[Value]] &raquo;).</ins>
       1. <ins>Otherwise,</ins>
-        1. Assert: _module_.[[Status]] is ~evaluated~ and _module_.[[EvaluationError]] is ~empty~.
-        1. <ins>If _module_.[[AsyncEvaluating]] is *false*, then</ins>
+        1. Assert: _module_.[[Status]] is <ins>~async-evaluating~ or</ins>~evaluated~ and _module_.[[EvaluationError]] is ~empty~.
+        1. <ins>If _module_.[[AsyncEvaluation]] is *false*, then</ins>
+          1. <ins>Assert: _module_.[[Status]] is ~evaluated~.</ins>
           1. <ins>Perform ! Call(_capability_.[[Resolve]], *undefined*, &laquo; *undefined* &raquo;).</ins>
         1. Assert: _stack_ is empty.
       1. Return <del>*undefined*</del><ins>_capability_.[[Promise]]</ins>.
@@ -561,7 +563,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
           1. If _promise_.[[PromiseState]] is ~rejected~, then
             1. Return ThrowCompletion(_promise_.[[PromiseStateResult]]).
           1. Return _index_.
-        1. If _module_.[[Status]] is ~evaluated~, then
+        1. If _module_.[[Status]] is ~evaluated~<ins> or ~async-evaluating~</ins>, then
           1. If _module_.[[EvaluationError]] is ~empty~, return _index_.
           1. Otherwise, return _module_.[[EvaluationError]].
         1. If _module_.[[Status]] is ~evaluating~, return _index_.
@@ -577,24 +579,26 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
           1. NOTE: Link must be completed successfully prior to invoking this method, so every requested module is guaranteed to resolve successfully.
           1. Set _index_ to ? InnerModuleEvaluation(_requiredModule_, _stack_, _index_).
           1. If _requiredModule_ is a Cyclic Module Record, then
-            1. Assert: _requiredModule_.[[Status]] is either ~evaluating~ or ~evaluated~.
+            1. Assert: _requiredModule_.[[Status]] is either ~evaluating~<ins>, ~async-evaluating~</ins> or ~evaluated~.
             1. Assert: _requiredModule_.[[Status]] is ~evaluating~ if and only if _requiredModule_ is in _stack_.
             1. If _requiredModule_.[[Status]] is ~evaluating~, then
               1. Set _module_.[[DFSAncestorIndex]] to min(_module_.[[DFSAncestorIndex]], _requiredModule_.[[DFSAncestorIndex]]).
             1. <ins>Otherwise,</ins>
               1. <ins>Set _requiredModule_ to _requiredModule_.[[CycleRoot]].</ins>
-              1. <ins>Assert: _requiredModule_.[[Status]] is ~evaluated~.</ins>
+              1. <ins>Assert: _requiredModule_.[[Status]] is ~async-evaluating~ or ~evaluated~.</ins>
               1. <ins>If _requiredModule_.[[EvaluationError]] is not ~empty~, return _requiredModule_.[[EvaluationError]].</ins>
-            1. <ins>If _requiredModule_.[[AsyncEvaluating]] is *true*, then</ins>
+            1. <ins>If _requiredModule_.[[AsyncEvaluation]] is *true*, then</ins>
               1. <ins>Set _module_.[[PendingAsyncDependencies]] to _module_.[[PendingAsyncDependencies]] + 1.</ins>
               1. <ins>Append _module_ to _requiredModule_.[[AsyncParentModules]].</ins>
         1. <del>Perform ? _module_.ExecuteModule().</del>
         1. <ins>If _module_.[[PendingAsyncDependencies]] &gt; 0 or _module_.[[Async]] is *true*, then</ins>
-          1. <ins>Assert: _module_.[[AsyncEvaluating]] is *false* and was never previously set to *true*.</ins>
-          1. <ins>Set _module_.[[AsyncEvaluating]] to *true*.</ins>
-          1. NOTE: The order in which modules transition to async evaluating is significant. (See <emu-xref href="#sec-async-module-execution-fulfilled"></emu-xref>)
+          1. <ins>Assert: _module_.[[AsyncEvaluation]] is ~empty~.</ins>
+          1. <ins>Set _module_.[[AsyncEvaluation]] to *true*.</ins>
+          1. NOTE: The order in which [[AsyncEvaluation]] transitions to *true* is significant. (See <emu-xref href="#sec-async-module-execution-fulfilled"></emu-xref>)
           1. <ins>If _module_.[[PendingAsyncDependencies]] is 0, perform ! ExecuteAsyncModule(_module_).</ins>
-        1. <ins>Otherwise, perform ? _module_.ExecuteModule().</ins>
+        1. <ins>Otherwise,</ins>
+          1. <ins>Set _module_.[[AsyncEvaluation]] to *false*.</ins>
+          1. <ins>Perform ? _module_.ExecuteModule().</ins>
         1. Assert: _module_ occurs exactly once in _stack_.
         1. Assert: _module_.[[DFSAncestorIndex]] is less than or equal to _module_.[[DFSIndex]].
         1. If _module_.[[DFSAncestorIndex]] equals _module_.[[DFSIndex]], then
@@ -604,13 +608,14 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             1. Let _requiredModule_ be the last element in _stack_.
             1. Remove the last element of _stack_.
             1. Assert: _requiredModule_ is a Cyclic Module Record.
-            1. Set _requiredModule_.[[Status]] to ~evaluated~.
+            1. <ins>If _requiredModule_.[[AsyncEvaluation]] is *false*, set _requiredModule_.[[Status]] to ~evaluated~.
+            1. <ins>Otherwise, set _requiredModule_.[[Status]] to ~async-evaluating~.</ins>
             1. If _requiredModule_ and _module_ are the same Module Record, set _done_ to *true*.
             1. <ins>Set _requiredModule_.[[CycleRoot]] to _cycleRoot_.</ins>
         1. Return _index_.
       </emu-alg>
       <emu-note>
-        <p><ins>A module is ~evaluating~ while it is being traversed by InnerModuleEvaluation. A module is ~evaluated~ on execution completion and during execution if it is an asynchronous module.</ins></p>
+        <p><ins>A module is ~evaluating~ while it is being traversed by InnerModuleEvaluation. A module is ~evaluated~ on execution completion or ~async-evaluating~ during execution if it is an asynchronous module.</ins></p>
       </emu-note>
       <emu-note>
         <p><ins>Any modules depending on a module of an async cycle when that cycle is not ~evaluating~ will instead depend on the execution of the root of the cycle via [[CycleRoot]]. This ensures that the cycle state can be treated as a single strongly connected component through its root module state.</ins></p>
@@ -620,7 +625,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
     <emu-clause id="sec-execute-async-module" aoid="ExecuteAsyncModule">
       <h1><ins>ExecuteAsyncModule ( _module_ )</ins></h1>
       <emu-alg>
-        1. Assert: _module_.[[Status]] is ~evaluating~ or ~evaluated~.
+        1. Assert: _module_.[[Status]] is ~async-evaluating~.
         1. Assert: _module_.[[Async]] is *true*.
         1. Let _capability_ be ! NewPromiseCapability(%Promise%).
         1. Let _stepsFulfilled_ be the steps of a CallAsyncModuleFulfilled function as specified below.
@@ -654,11 +659,11 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
     <emu-clause id="sec-gather-async-parent-completions" aoid="GatherAsyncParentCompletions">
       <h1><ins>GatherAsyncParentCompletions ( _module_, _execList_ )</ins></h1>
       <emu-alg>
-        1. Assert: _module_.[[Status]] is ~evaluated~.
+        1. Assert: _module_.[[Status]] is ~async-evaluating~.
         1. For each Module _m_ of _module_.[[AsyncParentModules]], do
           1. If _execList_ does not contain _m_ and _m_.[[CycleRoot]].[[EvaluationError]] is ~empty~, then
             1. Assert: _m_.[[EvaluationError]] is ~empty~.
-            1. Assert: _m_.[[AsyncEvaluating]] is *true*.
+            1. Assert: _m_.[[Status]] is ~async-evaluating~.
             1. Assert: _m_.[[PendingAsyncDependencies]] > 0.
             1. Set _m_.[[PendingAsyncDependencies]] to _m_.[[PendingAsyncDependencies]] - 1.
             1. If _m_.[[PendingAsyncDependencies]] is equal to 0, then
@@ -674,19 +679,20 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
     <emu-clause id="sec-async-module-execution-fulfilled" aoid="AsyncModuleExecutionFulfilled">
       <h1><ins>AsyncModuleExecutionFulfilled ( _module_ )</ins></h1>
       <emu-alg>
-        1. Assert: _module_.[[AsyncEvaluating]] is *true*.
+        1. Assert: _module_.[[Status]] is ~async-evaluating~.
+        1. Assert: _module_.[[AsyncEvaluation]] is *true*.
         1. Assert: _module_.[[EvaluationError]] is ~empty~.
-        1. Set _module_.[[AsyncEvaluating]] to *false*.
+        1. Set _module_.[[Status]] to ~evaluated~.
         1. If _module_.[[TopLevelCapability]] is not ~empty~, then
           1. Assert: _module_.[[CycleRoot]] is equal to _module_.
           1. Perform ! Call(_module_.[[TopLevelCapability]].[[Resolve]], *undefined*, &laquo;*undefined*&raquo;).
         1. Let _execList_ be a new empty List.
         1. Perform ! GatherAsyncParentCompletions(_module_, _execList_).
-        1. Let _sortedExecList_ be a List of elements that are the elements of _execList_, in the order in which they had their [[AsyncEvaluating]] fields set to *true* in InnerModuleEvaluation.
-        1. Assert: All elements of _sortedExecList_ have their [[AsyncEvaluating]] field set to *true*, [[PendingAsyncDependencies]] field set to 0 and [[EvaluationError]] field set to *undefined*.
+        1. Let _sortedExecList_ be a List of elements that are the elements of _execList_, in the order in which they had their [[AsyncEvaluation]] fields set to *true* in InnerModuleEvaluation.
+        1. Assert: All elements of _sortedExecList_ have their [[AsyncEvaluation]] field set to *true*, [[PendingAsyncDependencies]] field set to 0 and [[EvaluationError]] field set to *undefined*.
         1. For each Module _m_ of _sortedExecList_, do
-          1. If _m_.[[AsyncEvaluating]] is *false*, then
-            1. Assert: _m_.[[EvaluatingError]] is not ~empty~.
+          1. If _m_.[[Status]] is ~evaluated~, then
+            1. Assert: _m_.[[EvaluationError]] is not ~empty~.
           1. Otherwise, if _m_.[[Async]] is *true*, then
             1. Perform ! ExecuteAsyncModule(_m_).
           1. Otherwise,
@@ -694,7 +700,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             1. If _result_ is an abrupt completion,
               1. Perform ! AsyncModuleExecutionRejected(_m_, _result_.[[Value]]).
             1. Otherwise,
-              1. Set _m_.[[AsyncEvaluating]] to *false*.
+              1. Set _m_.[[Status]] to ~evaluated~.
               1. If _m_.[[TopLevelCapability]] is not ~empty~, then
                 1. Assert: _m_.[[CycleRoot]] is equal to _m_.
                 1. Perform ! Call(_m_.[[TopLevelCapability]].[[Resolve]], *undefined*, &laquo;*undefined*&raquo;).
@@ -705,13 +711,13 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
     <emu-clause id="sec-async-module-execution-rejected" aoid="AsyncModuleExecutionRejected">
       <h1><ins>AsyncModuleExecutionRejected ( _module_, _error_ )</ins></h1>
       <emu-alg>
-        1. Assert: _module_.[[Status]] is ~evaluated~.
-        1. If _module_.[[AsyncEvaluating]] is *false*,
+        1. If _module_.[[Status]] is ~evaluated~,
           1. Assert: _module_.[[EvaluationError]] is not ~empty~.
           1. Return *undefined*.
+        1. Assert: _module_.[[Status]] is ~async-evaluating~.
         1. Assert: _module_.[[EvaluationError]] is ~empty~.
         1. Set _module_.[[EvaluationError]] to ThrowCompletion(_error_).
-        1. Set _module_.[[AsyncEvaluating]] to *false*.
+        1. Set _module_.[[Status]] to ~evaluated~.
         1. For each Module _m_ of _module_.[[AsyncParentModules]], do
           1. Perform ! AsyncModuleExecutionRejected(_m_, _error_).
         1. If _module_.[[TopLevelCapability]] is not ~empty~, then
@@ -772,13 +778,13 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
     <p><ins>
       Calling _A_.Evaluate() triggers InnerModuleEvaluation on _A_, _B_, and _D_, which all transition to ~evaluating~.
       Then InnerModuleEvaluation is called on _A_ again, which is a no-op because it is already ~evaluating~.
-      At this point, _D_.[[PendingAsyncDependencies]] is 0, so ExecuteAsyncModule(_D_) is called, which sets _D_.[[AsyncEvaluating]] to *true* and triggers the execution promise for _D_.
-      We unwind back to the original InnerModuleEvaluation on _A_, setting _B_.[[AsyncEvaluating]] to *true*.
+      At this point, _D_.[[PendingAsyncDependencies]] is 0, so ExecuteAsyncModule(_D_) is called, which sets _D_.[[AsyncEvaluation]] to *true* and triggers the execution promise for _D_.
+      We unwind back to the original InnerModuleEvaluation on _A_, setting _B_.[[AsyncEvaluation]] to *true*.
       In the next iteration of the loop over _A_'s dependencies, we call InnerModuleEvaluation on _C_ and thus on _D_ (again a no-op) and _E_.
-      As _E_ has no dependencies, ExecuteAsyncModule(_E_) is called, which sets _E_.[[AsyncEvaluating]] to *true* and triggers its execution promise.
+      As _E_ has no dependencies, ExecuteAsyncModule(_E_) is called, which sets _E_.[[AsyncEvaluation]] to *true* and triggers its execution promise.
       Because _E_ is not part of a cycle, it is immediately removed from the stack and transitions to ~evaluated~.
-      We unwind once more to the original InnerModuleEvaluation on _A_, setting _C_.[[AsyncEvaluating]] to *true*.
-      Now we finish the loop over _A_'s dependencies, set _A_.[[AsyncEvaluating]] to *true*, and remove the entire strongly connected component from the stack, transitioning all of the modules to ~evaluated~ at once.
+      We unwind once more to the original InnerModuleEvaluation on _A_, setting _C_.[[AsyncEvaluation]] to *true*.
+      Now we finish the loop over _A_'s dependencies, set _A_.[[AsyncEvaluation]] to *true*, and remove the entire strongly connected component from the stack, transitioning all of the modules to ~evaluated~ at once.
       At this point, the fields of the modules are as given in <emu-xref href="#table-module-graph-cycle-async-fields-1"></emu-xref>.
     </ins></p>
 
@@ -789,7 +795,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>Module</th>
             <th>[[DFSIndex]]</th>
             <th>[[DFSAncestorIndex]]</th>
-            <th>[[AsyncEvaluating]]</th>
+            <th>[[AsyncEvaluation]]</th>
             <th>[[AsyncParentModules]]</th>
             <th>[[PendingAsyncDependencies]]</th>
           </tr>
@@ -841,7 +847,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
 
     <p><ins>
       Let us assume that _E_ finishes executing first.
-      When that happens, AsyncModuleExecutionFulfilled is called, _E_.[[AsyncEvaluating]] is set to *false* and _C_.[[PendingAsyncDependencies]] is decremented to become 1.
+      When that happens, AsyncModuleExecutionFulfilled is called, _E_.[[State]] is set to ~evaluated~ and _C_.[[PendingAsyncDependencies]] is decremented to become 1.
       The fields of the updated modules are as given in <emu-xref href="#table-module-graph-cycle-async-fields-2"></emu-xref>.
     </ins></p>
 
@@ -852,7 +858,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>Module</th>
             <th>[[DFSIndex]]</th>
             <th>[[DFSAncestorIndex]]</th>
-            <th>[[AsyncEvaluating]]</th>
+            <th>[[AsyncEvaluation]]</th>
             <th>[[AsyncParentModules]]</th>
             <th>[[PendingAsyncDependencies]]</th>
           </tr>
@@ -870,7 +876,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>_E_</th>
             <td>4</td>
             <td>4</td>
-            <td>*false*</td>
+            <td>*true*</td>
             <td>&laquo; _C_ &raquo;</td>
             <td>0</td>
           </tr>
@@ -880,7 +886,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
 
     <p><ins>
       _D_ is next to finish (as it was the only module that was still executing).
-      When that happens, AsyncModuleExecutionFulfilled is called again and _D_.[[AsyncEvaluating]] is set to *false*.
+      When that happens, AsyncModuleExecutionFulfilled is called again and _D_.[[State]] is set to ~evaluated~.
       Then _B_.[[PendingAsyncDependencies]] is decremented to become 0, ExecuteAsyncModule is called on _B_, and its execution is triggered.
       Once the synchronous part of _B_'s execution has finished, _C_.[[PendingAsyncDependencies]] is also decremented to become 0, and _C_'s execution is triggered.
       The fields of the updated modules are as given in <emu-xref href="#table-module-graph-cycle-async-fields-3"></emu-xref>.
@@ -893,7 +899,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>Module</th>
             <th>[[DFSIndex]]</th>
             <th>[[DFSAncestorIndex]]</th>
-            <th>[[AsyncEvaluating]]</th>
+            <th>[[AsyncEvaluation]]</th>
             <th>[[AsyncParentModules]]</th>
             <th>[[PendingAsyncDependencies]]</th>
           </tr>
@@ -929,7 +935,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
 
     <p><ins>
       Let us assume that _C_ finishes executing next.
-      When that happens, AsyncModuleExecutionFulfilled is called again, _C_.[[AsyncEvaluating]] is set to *false* and _A_.[[PendingAsyncDependencies]] is decremented to become 1.
+      When that happens, AsyncModuleExecutionFulfilled is called again, _C_.[[State]] is set to ~evaluated~ and _A_.[[PendingAsyncDependencies]] is decremented to become 1.
       The fields of the updated modules are as given in <emu-xref href="#table-module-graph-cycle-async-fields-4"></emu-xref>.
     </ins></p>
 
@@ -940,7 +946,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>Module</th>
             <th>[[DFSIndex]]</th>
             <th>[[DFSAncestorIndex]]</th>
-            <th>[[AsyncEvaluating]]</th>
+            <th>[[AsyncEvaluation]]</th>
             <th>[[AsyncParentModules]]</th>
             <th>[[PendingAsyncDependencies]]</th>
           </tr>
@@ -968,7 +974,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
 
     <p><ins>
       Then, _B_ finishes executing.
-      When that happens, AsyncModuleExecutionFulfilled is called again and _B_.[[AsyncEvaluating]] is set to *false*.
+      When that happens, AsyncModuleExecutionFulfilled is called again and _B_.[[State]] is set to ~evaluated~.
       _A_.[[PendingAsyncDependencies]] is decremented to become 0, so ExecuteAsyncModule is called and its execution is triggered.
       The fields of the updated modules are as given in <emu-xref href="#table-module-graph-cycle-async-fields-5"></emu-xref>.
     </ins></p>
@@ -980,7 +986,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>Module</th>
             <th>[[DFSIndex]]</th>
             <th>[[DFSAncestorIndex]]</th>
-            <th>[[AsyncEvaluating]]</th>
+            <th>[[AsyncEvaluation]]</th>
             <th>[[AsyncParentModules]]</th>
             <th>[[PendingAsyncDependencies]]</th>
           </tr>
@@ -1008,7 +1014,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
 
     <p><ins>
       Finally, _A_ finishes executing.
-      When that happens, AsyncModuleExecutionFulfilled is called again and _A_.[[AsyncEvaluating]] is set to *false*.
+      When that happens, AsyncModuleExecutionFulfilled is called again and _A_.[[State]] is set to ~evaluated~.
       At this point, the Promise in _A_.[[TopLevelCapability]] (which was returned from _A_.Evaluate()) is resolved, and this concludes the handling of this module graph.
       The fields of the updated module are as given in <emu-xref href="#table-module-graph-cycle-async-fields-6"></emu-xref>.
     </ins></p>
@@ -1020,7 +1026,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>Module</th>
             <th>[[DFSIndex]]</th>
             <th>[[DFSAncestorIndex]]</th>
-            <th>[[AsyncEvaluating]]</th>
+            <th>[[AsyncEvaluation]]</th>
             <th>[[AsyncParentModules]]</th>
             <th>[[PendingAsyncDependencies]]</th>
           </tr>
@@ -1183,7 +1189,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
         1. Else,
           1. Append _ee_ to _indirectExportEntries_.
       1. <ins>Let _async_ be _body_ Contains `await`.</ins>
-      1. Return Source Text Module Record { [[Realm]]: _realm_, [[Environment]]: ~empty~, [[Namespace]]: ~empty~, <ins>[[CycleRoot]]: ~empty~, [[Async]]: _async_, [[AsyncEvaluating]]: *false*, [[TopLevelCapability]]: ~empty~, [[AsyncParentModules]]: &laquo; &raquo;, [[PendingAsyncDependencies]]: ~empty~, </ins>[[Status]]: ~unlinked~, [[EvaluationError]]: ~empty~, [[HostDefined]]: _hostDefined_, [[ECMAScriptCode]]: _body_, [[Context]]: ~empty~, [[ImportMeta]]: ~empty~, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[DFSIndex]]: ~empty~, [[DFSAncestorIndex]]: ~empty~ }.
+      1. Return Source Text Module Record { [[Realm]]: _realm_, [[Environment]]: ~empty~, [[Namespace]]: ~empty~, <ins>[[CycleRoot]]: ~empty~, [[Async]]: _async_, [[AsyncEvaluation]]: ~empty~, [[TopLevelCapability]]: ~empty~, [[AsyncParentModules]]: &laquo; &raquo;, [[PendingAsyncDependencies]]: ~empty~, </ins>[[Status]]: ~unlinked~, [[EvaluationError]]: ~empty~, [[HostDefined]]: _hostDefined_, [[ECMAScriptCode]]: _body_, [[Context]]: ~empty~, [[ImportMeta]]: ~empty~, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[DFSIndex]]: ~empty~, [[DFSAncestorIndex]]: ~empty~ }.
     </emu-alg>
     <emu-note>
       <p>An implementation may parse module source text and analyse it for Early Error conditions prior to the evaluation of ParseModule for that module source text. However, the reporting of any errors must be deferred until the point where this specification actually performs ParseModule upon that source text.</p>

--- a/spec.html
+++ b/spec.html
@@ -364,7 +364,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
         </tr>
         <tr>
           <td>
-            <ins>[[QueuedEvaluation]]</ins>
+            <ins>[[AsyncEvaluation]]</ins>
           </td>
           <td>
             <ins>Boolean</ins>
@@ -544,7 +544,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
         1. <ins>Perform ! Call(_capability_.[[Reject]], *undefined*, &laquo; _result_.[[Value]] &raquo;).</ins>
       1. <ins>Otherwise,</ins>
         1. Assert: _module_.[[Status]] is <ins>~evaluating-async~ or</ins>~evaluated~ and _module_.[[EvaluationError]] is ~empty~.
-        1. <ins>If _module_.[[QueuedEvaluation]] is *false*, then</ins>
+        1. <ins>If _module_.[[AsyncEvaluation]] is *false*, then</ins>
           1. <ins>Assert: _module_.[[Status]] is ~evaluated~.</ins>
           1. <ins>Perform ! Call(_capability_.[[Resolve]], *undefined*, &laquo; *undefined* &raquo;).</ins>
         1. Assert: _stack_ is empty.
@@ -586,14 +586,14 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
               1. <ins>Set _requiredModule_ to _requiredModule_.[[CycleRoot]].</ins>
               1. <ins>Assert: _requiredModule_.[[Status]] is ~evaluating-async~ or ~evaluated~.</ins>
               1. <ins>If _requiredModule_.[[EvaluationError]] is not ~empty~, return _requiredModule_.[[EvaluationError]].</ins>
-            1. <ins>If _requiredModule_.[[QueuedEvaluation]] is *true*, then</ins>
+            1. <ins>If _requiredModule_.[[AsyncEvaluation]] is *true*, then</ins>
               1. <ins>Set _module_.[[PendingAsyncDependencies]] to _module_.[[PendingAsyncDependencies]] + 1.</ins>
               1. <ins>Append _module_ to _requiredModule_.[[AsyncParentModules]].</ins>
         1. <del>Perform ? _module_.ExecuteModule().</del>
         1. <ins>If _module_.[[PendingAsyncDependencies]] &gt; 0 or _module_.[[Async]] is *true*, then</ins>
-          1. <ins>Assert: _module_.[[QueuedEvaluation]] is *false*.</ins>
-          1. <ins>Set _module_.[[QueuedEvaluation]] to *true*.</ins>
-          1. <ins>NOTE: The order in which [[QueuedEvaluation]] transitions to *true* is significant. (See <emu-xref href="#sec-async-module-execution-fulfilled"></emu-xref>)</ins>
+          1. <ins>Assert: _module_.[[AsyncEvaluation]] is *false*.</ins>
+          1. <ins>Set _module_.[[AsyncEvaluation]] to *true*.</ins>
+          1. <ins>NOTE: The order in which [[AsyncEvaluation]] transitions to *true* is significant. (See <emu-xref href="#sec-async-module-execution-fulfilled"></emu-xref>)</ins>
           1. <ins>If _module_.[[PendingAsyncDependencies]] is 0, perform ! ExecuteAsyncModule(_module_).</ins>
         1. <ins>Otherwise, perform ? _module_.ExecuteModule().</ins>
         1. Assert: _module_ occurs exactly once in _stack_.
@@ -604,7 +604,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             1. Let _requiredModule_ be the last element in _stack_.
             1. Remove the last element of _stack_.
             1. Assert: _requiredModule_ is a Cyclic Module Record.
-            1. <ins>If _requiredModule_.[[QueuedEvaluation]] is *false*, set _requiredModule_.[[Status]] to ~evaluated~.</ins>
+            1. <ins>If _requiredModule_.[[AsyncEvaluation]] is *false*, set _requiredModule_.[[Status]] to ~evaluated~.</ins>
             1. <ins>Otherwise, set _requiredModule_.[[Status]] to ~evaluating-async~.</ins>
             1. If _requiredModule_ and _module_ are the same Module Record, set _done_ to *true*.
             1. <ins>Set _requiredModule_.[[CycleRoot]] to _module_.</ins>
@@ -659,7 +659,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
           1. If _execList_ does not contain _m_ and _m_.[[CycleRoot]].[[EvaluationError]] is ~empty~, then
             1. Assert: _m_.[[Status]] is ~evaluating-async~.
             1. Assert: _m_.[[EvaluationError]] is ~empty~.
-            1. Assert: _m_.[[QueuedEvaluation]] is *true*.
+            1. Assert: _m_.[[AsyncEvaluation]] is *true*.
             1. Assert: _m_.[[PendingAsyncDependencies]] > 0.
             1. Set _m_.[[PendingAsyncDependencies]] to _m_.[[PendingAsyncDependencies]] - 1.
             1. If _m_.[[PendingAsyncDependencies]] is equal to 0, then
@@ -679,7 +679,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
           1. Assert: _module_.[[EvaluationError]] is not ~empty~.
           1. Return *undefined*.
         1. Assert: _module_.[[Status]] is ~evaluating-async~.
-        1. Assert: _module_.[[QueuedEvaluation]] is *true*.
+        1. Assert: _module_.[[AsyncEvaluation]] is *true*.
         1. Assert: _module_.[[EvaluationError]] is ~empty~.
         1. Set _module_.[[Status]] to ~evaluated~.
         1. If _module_.[[TopLevelCapability]] is not ~empty~, then
@@ -687,8 +687,8 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
           1. Perform ! Call(_module_.[[TopLevelCapability]].[[Resolve]], *undefined*, &laquo;*undefined*&raquo;).
         1. Let _execList_ be a new empty List.
         1. Perform ! GatherAsyncParentCompletions(_module_, _execList_).
-        1. Let _sortedExecList_ be a List of elements that are the elements of _execList_, in the order in which they had their [[QueuedEvaluation]] fields set to *true* in InnerModuleEvaluation.
-        1. Assert: All elements of _sortedExecList_ have their [[QueuedEvaluation]] field set to *true*, [[PendingAsyncDependencies]] field set to 0 and [[EvaluationError]] field set to *undefined*.
+        1. Let _sortedExecList_ be a List of elements that are the elements of _execList_, in the order in which they had their [[AsyncEvaluation]] fields set to *true* in InnerModuleEvaluation.
+        1. Assert: All elements of _sortedExecList_ have their [[AsyncEvaluation]] field set to *true*, [[PendingAsyncDependencies]] field set to 0 and [[EvaluationError]] field set to *undefined*.
         1. For each Module _m_ of _sortedExecList_, do
           1. If _m_.[[Status]] is ~evaluated~, then
             1. Assert: _m_.[[EvaluationError]] is not ~empty~.
@@ -714,7 +714,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
           1. Assert: _module_.[[EvaluationError]] is not ~empty~.
           1. Return *undefined*.
         1. Assert: _module_.[[Status]] is ~evaluating-async~.
-        1. Assert: _module_.[[QueuedEvaluation]] is *true*.
+        1. Assert: _module_.[[AsyncEvaluation]] is *true*.
         1. Assert: _module_.[[EvaluationError]] is ~empty~.
         1. Set _module_.[[EvaluationError]] to ThrowCompletion(_error_).
         1. Set _module_.[[Status]] to ~evaluated~.
@@ -779,13 +779,13 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
       Calling _A_.Evaluate() triggers InnerModuleEvaluation on _A_, _B_, and _D_, which all transition to ~evaluating~.
       Then InnerModuleEvaluation is called on _A_ again, which is a no-op because it is already ~evaluating~.
       At this point, _D_.[[PendingAsyncDependencies]] is 0, so ExecuteAsyncModule(_D_) is called and triggers the execution promise for _D_.
-      We unwind back to the InnerModuleEvaluation on _B_, setting _B_.[[PendingAsyncDependencies]] to 1 and _B_.[[QueuedEvaluation]] to *true*.
+      We unwind back to the InnerModuleEvaluation on _B_, setting _B_.[[PendingAsyncDependencies]] to 1 and _B_.[[AsyncEvaluation]] to *true*.
       We unwind back to the original InnerModuleEvaluation on _A_, setting _A_.[[PendingAsyncDependencies]] to 1.
       In the next iteration of the loop over _A_'s dependencies, we call InnerModuleEvaluation on _C_ and thus on _D_ (again a no-op) and _E_.
       As _E_ has no dependencies, ExecuteAsyncModule(_E_) is called, which triggers its execution promise.
       Because _E_ is not part of a cycle, it is immediately removed from the stack and transitions to ~evaluated~.
-      We unwind once more to the original InnerModuleEvaluation on _A_, setting _C_.[[QueuedEvaluation]] to *true*.
-      Now we finish the loop over _A_'s dependencies, set _A_.[[QueuedEvaluation]] to *true*, and remove the entire strongly connected component from the stack, transitioning all of the modules to ~evaluating-async~ at once.
+      We unwind once more to the original InnerModuleEvaluation on _A_, setting _C_.[[AsyncEvaluation]] to *true*.
+      Now we finish the loop over _A_'s dependencies, set _A_.[[AsyncEvaluation]] to *true*, and remove the entire strongly connected component from the stack, transitioning all of the modules to ~evaluating-async~ at once.
       At this point, the fields of the modules are as given in <emu-xref href="#table-module-graph-cycle-async-fields-1"></emu-xref>.
     </ins></p>
 
@@ -797,7 +797,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>[[DFSIndex]]</th>
             <th>[[DFSAncestorIndex]]</th>
             <th>[[Status]]</th>
-            <th>[[QueuedEvaluation]]</th>
+            <th>[[AsyncEvaluation]]</th>
             <th>[[AsyncParentModules]]</th>
             <th>[[PendingAsyncDependencies]]</th>
           </tr>
@@ -866,7 +866,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>[[DFSIndex]]</th>
             <th>[[DFSAncestorIndex]]</th>
             <th>[[Status]]</th>
-            <th>[[QueuedEvaluation]]</th>
+            <th>[[AsyncEvaluation]]</th>
             <th>[[AsyncParentModules]]</th>
             <th>[[PendingAsyncDependencies]]</th>
           </tr>
@@ -910,7 +910,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>[[DFSIndex]]</th>
             <th>[[DFSAncestorIndex]]</th>
             <th>[[Status]]</th>
-            <th>[[QueuedEvaluation]]</th>
+            <th>[[AsyncEvaluation]]</th>
             <th>[[AsyncParentModules]]</th>
             <th>[[PendingAsyncDependencies]]</th>
           </tr>
@@ -961,7 +961,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>[[DFSIndex]]</th>
             <th>[[DFSAncestorIndex]]</th>
             <th>[[Status]]</th>
-            <th>[[QueuedEvaluation]]</th>
+            <th>[[AsyncEvaluation]]</th>
             <th>[[AsyncParentModules]]</th>
             <th>[[PendingAsyncDependencies]]</th>
           </tr>
@@ -1004,7 +1004,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>[[DFSIndex]]</th>
             <th>[[DFSAncestorIndex]]</th>
             <th>[[Status]]</th>
-            <th>[[QueuedEvaluation]]</th>
+            <th>[[AsyncEvaluation]]</th>
             <th>[[AsyncParentModules]]</th>
             <th>[[PendingAsyncDependencies]]</th>
           </tr>
@@ -1047,7 +1047,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>[[DFSIndex]]</th>
             <th>[[DFSAncestorIndex]]</th>
             <th>[[Status]]</th>
-            <th>[[QueuedEvaluation]]</th>
+            <th>[[AsyncEvaluation]]</th>
             <th>[[AsyncParentModules]]</th>
             <th>[[PendingAsyncDependencies]]</th>
           </tr>
@@ -1078,7 +1078,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>[[DFSIndex]]</th>
             <th>[[DFSAncestorIndex]]</th>
             <th>[[Status]]</th>
-            <th>[[QueuedEvaluation]]</th>
+            <th>[[AsyncEvaluation]]</th>
             <th>[[AsyncParentModules]]</th>
             <th>[[PendingAsyncDependencies]]</th>
             <th>[[EvaluationError]]</th>
@@ -1120,7 +1120,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>[[DFSIndex]]</th>
             <th>[[DFSAncestorIndex]]</th>
             <th>[[Status]]</th>
-            <th>[[QueuedEvaluation]]</th>
+            <th>[[AsyncEvaluation]]</th>
             <th>[[AsyncParentModules]]</th>
             <th>[[PendingAsyncDependencies]]</th>
             <th>[[EvaluationError]]</th>
@@ -1153,7 +1153,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <th>[[DFSIndex]]</th>
             <th>[[DFSAncestorIndex]]</th>
             <th>[[Status]]</th>
-            <th>[[QueuedEvaluation]]</th>
+            <th>[[AsyncEvaluation]]</th>
             <th>[[AsyncParentModules]]</th>
             <th>[[PendingAsyncDependencies]]</th>
             <th>[[EvaluationError]]</th>
@@ -1219,7 +1219,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
         1. Else,
           1. Append _ee_ to _indirectExportEntries_.
       1. <ins>Let _async_ be _body_ Contains `await`.</ins>
-      1. Return Source Text Module Record { [[Realm]]: _realm_, [[Environment]]: ~empty~, [[Namespace]]: ~empty~, <ins>[[CycleRoot]]: ~empty~, [[Async]]: _async_, [[QueuedEvaluation]]: *false*, [[TopLevelCapability]]: ~empty~, [[AsyncParentModules]]: &laquo; &raquo;, [[PendingAsyncDependencies]]: ~empty~, </ins>[[Status]]: ~unlinked~, [[EvaluationError]]: ~empty~, [[HostDefined]]: _hostDefined_, [[ECMAScriptCode]]: _body_, [[Context]]: ~empty~, [[ImportMeta]]: ~empty~, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[DFSIndex]]: ~empty~, [[DFSAncestorIndex]]: ~empty~ }.
+      1. Return Source Text Module Record { [[Realm]]: _realm_, [[Environment]]: ~empty~, [[Namespace]]: ~empty~, <ins>[[CycleRoot]]: ~empty~, [[Async]]: _async_, [[AsyncEvaluation]]: *false*, [[TopLevelCapability]]: ~empty~, [[AsyncParentModules]]: &laquo; &raquo;, [[PendingAsyncDependencies]]: ~empty~, </ins>[[Status]]: ~unlinked~, [[EvaluationError]]: ~empty~, [[HostDefined]]: _hostDefined_, [[ECMAScriptCode]]: _body_, [[Context]]: ~empty~, [[ImportMeta]]: ~empty~, [[RequestedModules]]: _requestedModules_, [[ImportEntries]]: _importEntries_, [[LocalExportEntries]]: _localExportEntries_, [[IndirectExportEntries]]: _indirectExportEntries_, [[StarExportEntries]]: _starExportEntries_, [[DFSIndex]]: ~empty~, [[DFSAncestorIndex]]: ~empty~ }.
     </emu-alg>
     <emu-note>
       <p>An implementation may parse module source text and analyse it for Early Error conditions prior to the evaluation of ParseModule for that module source text. However, the reporting of any errors must be deferred until the point where this specification actually performs ParseModule upon that source text.</p>

--- a/spec.html
+++ b/spec.html
@@ -370,7 +370,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <ins>*true* | *false* | ~empty~</ins>
           </td>
           <td>
-            <ins>Whether this module has one or more asynchronous dependencies so that its evaluation is queued on their completion.</ins>
+            <ins>Whether this module is either itself async or has an asynchronous dependency.</ins>
           </td>
         </tr>
         <tr>
@@ -544,7 +544,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
         1. <ins>Perform ! Call(_capability_.[[Reject]], *undefined*, &laquo; _result_.[[Value]] &raquo;).</ins>
       1. <ins>Otherwise,</ins>
         1. Assert: _module_.[[Status]] is <ins>~async-evaluating~ or</ins>~evaluated~ and _module_.[[EvaluationError]] is ~empty~.
-        1. <ins>If _module_.[[Async]] is *false* and _module_.[[QueuedEvaluation]] is *false*, then</ins>
+        1. <ins>If _module_.[[QueuedEvaluation]] is *false*, then</ins>
           1. <ins>Assert: _module_.[[Status]] is ~evaluated~.</ins>
           1. <ins>Perform ! Call(_capability_.[[Resolve]], *undefined*, &laquo; *undefined* &raquo;).</ins>
         1. Assert: _stack_ is empty.
@@ -586,18 +586,18 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
               1. <ins>Set _requiredModule_ to _requiredModule_.[[CycleRoot]].</ins>
               1. <ins>Assert: _requiredModule_.[[Status]] is ~async-evaluating~ or ~evaluated~.</ins>
               1. <ins>If _requiredModule_.[[EvaluationError]] is not ~empty~, return _requiredModule_.[[EvaluationError]].</ins>
-            1. <ins>If _requiredModule_.[[Async]] is *true* or _requiredModule_.[[QueuedEvaluation]] is *true*, then</ins>
+            1. <ins>If _requiredModule_.[[QueuedEvaluation]] is *true*, then</ins>
               1. <ins>Set _module_.[[PendingAsyncDependencies]] to _module_.[[PendingAsyncDependencies]] + 1.</ins>
               1. <ins>Append _module_ to _requiredModule_.[[AsyncParentModules]].</ins>
         1. <del>Perform ? _module_.ExecuteModule().</del>
-        1. <ins>If _module_.[[PendingAsyncDependencies]] &gt; 0, then</ins>
+        1. <ins>If _module_.[[PendingAsyncDependencies]] &gt; 0 or _module_.[[Async]] is *true*, then</ins>
           1. <ins>Assert: _module_.[[QueuedEvaluation]] is ~empty~.</ins>
           1. <ins>Set _module_.[[QueuedEvaluation]] to *true*.</ins>
           1. NOTE: The order in which [[QueuedEvaluation]] transitions to *true* is significant. (See <emu-xref href="#sec-async-module-execution-fulfilled"></emu-xref>)
+          1. <ins>If _module_.[[PendingAsyncDependencies]] is 0, perform ! ExecuteAsyncModule(_module_).</ins>
         1. <ins>Otherwise,</ins>
           1. <ins>Set _module_.[[QueuedEvaluation]] to *false*.</ins>
-          1. <ins>If _module_.[[Async]] is *true*, perform ! ExecuteAsyncModule(_module_).</ins>
-          1. <ins>Otherwise, perform ? _module_.ExecuteModule().</ins>
+          1. <ins>Perform ? _module_.ExecuteModule().</ins>
         1. Assert: _module_ occurs exactly once in _stack_.
         1. Assert: _module_.[[DFSAncestorIndex]] is less than or equal to _module_.[[DFSIndex]].
         1. If _module_.[[DFSAncestorIndex]] equals _module_.[[DFSIndex]], then
@@ -680,7 +680,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
       <h1><ins>AsyncModuleExecutionFulfilled ( _module_ )</ins></h1>
       <emu-alg>
         1. Assert: _module_.[[Status]] is ~async-evaluating~.
-        1. Assert: _module_.[[Async]] is *true* or _module_.[[QueuedEvaluation]] is *true*.
+        1. Assert: _module_.[[QueuedEvaluation]] is *true*.
         1. Assert: _module_.[[EvaluationError]] is ~empty~.
         1. Set _module_.[[Status]] to ~evaluated~.
         1. If _module_.[[TopLevelCapability]] is not ~empty~, then
@@ -835,7 +835,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <td>3</td>
             <td>0</td>
             <td>~async-evaluating~</td>
-            <td>*false*</td>
+            <td>*true*</td>
             <td>&laquo; _B_, _C_ &raquo;</td>
             <td>0</td>
           </tr>
@@ -844,7 +844,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <td>4</td>
             <td>4</td>
             <td>~async-evaluating~</td>
-            <td>*false*</td>
+            <td>*true*</td>
             <td>&laquo; _C_ &raquo;</td>
             <td>0</td>
           </tr>
@@ -854,7 +854,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
 
     <p><ins>
       Let us assume that _E_ finishes executing first.
-      When that happens, AsyncModuleExecutionFulfilled is called, _E_.[[State]] is set to ~evaluated~ and _C_.[[PendingAsyncDependencies]] is decremented to become 1.
+      When that happens, AsyncModuleExecutionFulfilled is called, _E_.[[Status]] is set to ~evaluated~ and _C_.[[PendingAsyncDependencies]] is decremented to become 1.
       The fields of the updated modules are as given in <emu-xref href="#table-module-graph-cycle-async-fields-2"></emu-xref>.
     </ins></p>
 
@@ -886,7 +886,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <td>4</td>
             <td>4</td>
             <td>~evaluated~</td>
-            <td>*false*</td>
+            <td>*true*</td>
             <td>&laquo; _C_ &raquo;</td>
             <td>0</td>
           </tr>
@@ -896,7 +896,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
 
     <p><ins>
       _D_ is next to finish (as it was the only module that was still executing).
-      When that happens, AsyncModuleExecutionFulfilled is called again and _D_.[[State]] is set to ~evaluated~.
+      When that happens, AsyncModuleExecutionFulfilled is called again and _D_.[[Status]] is set to ~evaluated~.
       Then _B_.[[PendingAsyncDependencies]] is decremented to become 0, ExecuteAsyncModule is called on _B_, and its execution is triggered.
       _C_.[[PendingAsyncDependencies]] is also decremented to become 0, and _C_'s execution is triggered.
       The fields of the updated modules are as given in <emu-xref href="#table-module-graph-cycle-async-fields-3"></emu-xref>.
@@ -939,7 +939,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
             <td>3</td>
             <td>0</td>
             <td>~evaluated~</td>
-            <td>*false*</td>
+            <td>*true*</td>
             <td>&laquo; _B_, _C_ &raquo;</td>
             <td>0</td>
           </tr>
@@ -949,7 +949,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
 
     <p><ins>
       Let us assume that _C_ finishes executing next.
-      When that happens, AsyncModuleExecutionFulfilled is called again, _C_.[[State]] is set to ~evaluated~ and _A_.[[PendingAsyncDependencies]] is decremented to become 1.
+      When that happens, AsyncModuleExecutionFulfilled is called again, _C_.[[Status]] is set to ~evaluated~ and _A_.[[PendingAsyncDependencies]] is decremented to become 1.
       The fields of the updated modules are as given in <emu-xref href="#table-module-graph-cycle-async-fields-4"></emu-xref>.
     </ins></p>
 
@@ -991,7 +991,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
 
     <p><ins>
       Then, _B_ finishes executing.
-      When that happens, AsyncModuleExecutionFulfilled is called again and _B_.[[State]] is set to ~evaluated~.
+      When that happens, AsyncModuleExecutionFulfilled is called again and _B_.[[Status]] is set to ~evaluated~.
       _A_.[[PendingAsyncDependencies]] is decremented to become 0, so ExecuteAsyncModule is called and _A_'s execution is triggered.
       The fields of the updated modules are as given in <emu-xref href="#table-module-graph-cycle-async-fields-5"></emu-xref>.
     </ins></p>
@@ -1034,7 +1034,7 @@ contributors: Myles Borins, Yulia Startsev, Daniel Ehrenberg, Guy Bedford, Ms2ge
 
     <p><ins>
       Finally, _A_ finishes executing.
-      When that happens, AsyncModuleExecutionFulfilled is called again and _A_.[[State]] is set to ~evaluated~.
+      When that happens, AsyncModuleExecutionFulfilled is called again and _A_.[[Status]] is set to ~evaluated~.
       At this point, the Promise in _A_.[[TopLevelCapability]] (which was returned from _A_.Evaluate()) is resolved, and this concludes the handling of this module graph.
       The fields of the updated module are as given in <emu-xref href="#table-module-graph-cycle-async-fields-6"></emu-xref>.
     </ins></p>


### PR DESCRIPTION
This is in response to https://github.com/tc39/proposal-top-level-await/issues/171 by @kmiller68 where the usage of the `~evaluated~` state to indicate modules that are still currently async evaluating could be seen to be a confusing state definition. In addition, addressing a possible confusion that the `[[AsyncEvaluating]]` state has also been misunderstood before since it applies to both queued executions and running executions.

This is an editorial change which brings back the `~async-evaluating~` `[[Status]]` value which is set for any module either currently asynchronously executing, or waiting on a dependency that is currently asynchronously executing and also renaming `[[AsyncEvaluating]]` to `[[QueuedEvaluation]]` with a slight adjustment to completion handling where instead of treating execution completion as the transition of `AsyncEvaluating` to false as before, we then treat execution completion as the transition of the `async-evaluating` state to `evaluated`.

The previous issue with the `~async-evaluating~` status was that we still needed a separate field for `AsyncEvaluating` due to handling cycle transitions, as discussed in https://github.com/tc39/proposal-top-level-await/pull/114. The `QueuedEvaluation` field then still provides three purposes: iindicates which modules have async dependencies, it acts as the counter for async execution ordering and it handles within-cycle async queue attachment.

This PR can be seen as performing the following (non-normative) editorial replacement operations in order:

* Replace all `~evaluated~` state checks with a check for `~evaluated~` or `~evaluating-async~`.
* Replace the `~evaluating~ -> ~evaluated~` transition for async executions with an `~evaluating~ -> ~evaluating-async~` transition.
* Rename `[[AsyncEvaluating]]` to `[[AsyncEvaluation]]`.
* Append a transition of `[[Status]]` from `evaluating-async -> evaluating` at all sites where we previously set `[[AsyncEvaluating]]` to false.
* Never transition `[[AsyncEvaluation]]` back to false, and instead entirely use the `[[State]] == ~evaluated~` transitions for these checks.

This is editorial since the `[[Status]]` is currently entirely private to the module execution semantics, so this editorial change is more about understandability and ensuring the underlying state model is as clear as possible for future module system additions.